### PR TITLE
docs(LICENSE): add LICENSE and OPEN_HARDWARE files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,48 @@
+# Licensing
+
+This repository uses a split-license model:
+
+- Hardware design source files are licensed under `CERN-OHL-W-2.0`.
+- Software/scripts are licensed under `Apache-2.0`.
+- Documentation is licensed under `CC-BY-4.0`.
+
+## Scope by path
+
+### Hardware design (`CERN-OHL-W-2.0`)
+
+Applies to:
+
+- `kicad/**/*.kicad_sch`
+- `kicad/**/*.kicad_pcb`
+- `kicad/**/*.kicad_pro`
+- `kicad/**/*.kicad_sym`
+- `kicad/**/*.kicad_mod`
+- `kicad/**/*-lib-table`
+- Other KiCad source assets in `kicad/` (templates, custom libraries, project assets)
+
+### Software and automation (`Apache-2.0`)
+
+Applies to:
+
+- `.github/workflows/**`
+- `tests/**`
+- Shell scripts and tooling scripts added in this repository
+
+### Documentation (`CC-BY-4.0`)
+
+Applies to:
+
+- `README.md`
+- `docs/**`
+- `OPEN_HARDWARE.md`
+- Markdown/text documentation files not listed above
+
+## Notes
+
+- Generated output files (for example Gerbers, PDFs, images, reports) inherit the license of their corresponding source inputs unless otherwise stated.
+- Third-party libraries/components/models remain under their respective upstream licenses.
+- Add canonical license texts under a `LICENSES/` directory:
+  - `LICENSES/CERN-OHL-W-2.0.txt`
+  - `LICENSES/Apache-2.0.txt`
+  - `LICENSES/CC-BY-4.0.txt`
+

--- a/OPEN_HARDWARE.md
+++ b/OPEN_HARDWARE.md
@@ -1,0 +1,57 @@
+# Open Hardware Disclosure
+
+This document captures the key open hardware disclosures for `seven-hardware`.
+
+## Project
+
+- Name: `seven-hardware`
+- Repository: `https://github.com/<org-or-user>/seven-hardware`
+- Current design source path: `kicad/`
+
+## Open source hardware license
+
+- Hardware design files are licensed under `CERN-OHL-W-2.0`.
+- See `LICENSE.md` for full path-based license mapping.
+
+## Source files provided
+
+The complete editable source for this hardware project is in:
+
+- `kicad/seven.kicad_sch`
+- `kicad/seven.kicad_pcb`
+- `kicad/seven.kicad_pro`
+- `kicad/sym-lib/**`
+- `kicad/fp-lib/**`
+- `kicad/*-lib-table`
+
+## Build/manufacturing outputs
+
+CI or local generation may produce artifacts such as:
+
+- ERC/DRC reports
+- Gerbers and drill files
+- Assembly/position files
+- Schematic PDF
+- PCB render images
+- BOM exports
+
+These are generated from the above source files and are intended to support fabrication and review.
+
+## Dependencies and third-party content
+
+This project may reference external libraries and models (for example KiCad system symbol libraries, footprint libraries, and 3D models).
+
+- Third-party content is governed by its own upstream license.
+- Where possible, references should resolve from project-local libraries committed in this repository.
+
+## Modification and redistribution
+
+Under `CERN-OHL-W-2.0`, recipients can study, modify, make, and distribute products based on this design, subject to the terms of that license.
+
+## Maintainer checklist (recommended)
+
+- Keep project library tables (`sym-lib-table`, `fp-lib-table`) committed.
+- Keep design source and generated release artifacts traceable by version/tag.
+- Document any required proprietary or external dependencies clearly.
+- Keep `LICENSE.md` and this file up to date when repository structure changes.
+


### PR DESCRIPTION
Pr example for licensing SEVEN project.
Example is proposed by chatGPT.
related to #18 

# chatGPT explains:
We are introducing a split-license model for **seven-hardware** and adding explicit open hardware disclosure documentation.

### What was added

1. **LICENSE.md**
   Defines which license applies to which part of the repository (path-based mapping).

2. **OPEN_HARDWARE.md**
   Documents hardware source availability, generated outputs, third-party dependency expectations, and reuse rights.

### Why this is beneficial

1. **Hardware and software are different legal artifacts**
   A hardware-specific license (CERN-OHL-W-2.0) is better suited for KiCad design files than relying solely on a software license.

2. **Clear rights for contributors and users**
   Contributors and users can quickly understand what they are allowed to modify, manufacture, redistribute, and under which terms.

3. **Better compliance with OSHWA-style open hardware practices**
   Explicit source and licensing disclosures reduce ambiguity during certification or review.

4. **Cleaner repository governance**
   Scripts can remain permissively licensed under Apache-2.0, documentation under CC-BY-4.0, while hardware stays properly open under CERN-OHL.

5. **Less CI/release confusion**
   Path-based ownership clarifies how generated artifacts and design sources relate.

### Proposed license mapping

* `kicad/**` → CERN-OHL-W-2.0
* `.github/workflows/**`, `tests/**`, `scripts/**` → Apache-2.0
* `README.md`, `docs/**`, other Markdown documentation → CC-BY-4.0

### Follow-up required

1. Add canonical license texts in `LICENSES/`:

   * CERN-OHL-W-2.0
   * Apache-2.0
   * CC-BY-4.0

2. Replace the placeholder repository URL in `OPEN_HARDWARE.md`.
