### PR TITLE
fix: changes made according to review meeting

### DIFF
--- a/kicad/JTAG.kicad_sch
+++ b/kicad/JTAG.kicad_sch
@@ -393,6 +393,113 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "seven_lib:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 	)
 	(text "\n\n"
 		(exclude_from_sim no)
@@ -468,13 +575,25 @@
 		)
 		(uuid "5d762859-1aff-4623-a06b-60ad08af630e")
 	)
+	(junction
+		(at 107.95 92.71)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1491f4b5-8cdd-4a25-8245-c2b50586e6f9")
+	)
+	(junction
+		(at 107.95 95.25)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "84395902-d1c5-4640-84e7-a294a34e3b0c")
+	)
 	(no_connect
 		(at 104.14 97.79)
 		(uuid "5145dab9-17a5-44c7-a4e2-9d56926e7508")
 	)
 	(wire
 		(pts
-			(xy 105.41 95.25) (xy 104.14 95.25)
+			(xy 109.22 95.25) (xy 107.95 95.25)
 		)
 		(stroke
 			(width 0)
@@ -484,7 +603,27 @@
 	)
 	(wire
 		(pts
-			(xy 105.41 92.71) (xy 104.14 92.71)
+			(xy 107.95 95.25) (xy 104.14 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0bb4624f-1a68-4544-a8f4-dccf9c5edeef")
+	)
+	(wire
+		(pts
+			(xy 107.95 77.47) (xy 107.95 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23ba6d02-8317-42ec-af8d-c7e3ee302558")
+	)
+	(wire
+		(pts
+			(xy 109.22 92.71) (xy 107.95 92.71)
 		)
 		(stroke
 			(width 0)
@@ -502,6 +641,16 @@
 		)
 		(uuid "a3599669-b5bf-4756-9e7e-240042a0423c")
 	)
+	(wire
+		(pts
+			(xy 107.95 102.87) (xy 107.95 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "af6b071e-713a-49ca-8f1e-b5c2843fedeb")
+	)
 	(polyline
 		(pts
 			(xy 176.53 77.47) (xy 284.48 77.47)
@@ -511,6 +660,16 @@
 			(type dash)
 		)
 		(uuid "bdeee825-249b-4b80-8b2c-ce01adb8c63e")
+	)
+	(wire
+		(pts
+			(xy 104.14 92.71) (xy 107.95 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c8ceba54-6fe4-4913-9fa5-bfc040899674")
 	)
 	(wire
 		(pts
@@ -532,7 +691,7 @@
 		)
 		(uuid "f195e9d5-13c3-42e5-adf5-3a43c60c71f4")
 	)
-	(global_label "VDD_3V3"
+	(global_label "VDD_JTAG"
 		(shape input)
 		(at 78.74 92.71 180)
 		(fields_autoplaced yes)
@@ -542,9 +701,9 @@
 			)
 			(justify right)
 		)
-		(uuid "8584713e-c259-4a5b-9c0e-8448f926cbd9")
+		(uuid "83c112c7-599c-4965-a22c-c525ad9996e8")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 67.651 92.71 0)
+			(at 66.8648 92.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -556,7 +715,7 @@
 	)
 	(hierarchical_label "SWDIO"
 		(shape bidirectional)
-		(at 105.41 92.71 0)
+		(at 109.22 92.71 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -578,7 +737,7 @@
 	)
 	(hierarchical_label "SWCLK"
 		(shape output)
-		(at 105.41 95.25 0)
+		(at 109.22 95.25 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -669,6 +828,70 @@
 		)
 	)
 	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 107.95 102.87 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "7df0a5b9-8984-4f46-869a-f91df29bfcc3")
+		(property "Reference" "TP10"
+			(at 104.013 104.775 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SWCLK"
+			(at 104.013 107.315 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 102.87 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 102.87 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 107.95 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4aee95e8-4b5b-42be-914d-f50a56f26469")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/05f18bcb-1f58-4fb2-bbec-23b1ba834d60"
+					(reference "TP10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "seven_lib:GND")
 		(at 78.74 97.79 270)
 		(unit 1)
@@ -730,6 +953,70 @@
 			(project "seven"
 				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/05f18bcb-1f58-4fb2-bbec-23b1ba834d60"
 					(reference "#PWR05")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 107.95 77.47 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b7d77921-79d5-4eca-884f-0d8688174288")
+		(property "Reference" "TP9"
+			(at 111.633 73.025 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SWDIO"
+			(at 111.633 75.565 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 113.03 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 113.03 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 107.95 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a398e510-83e2-452d-960b-742cfd587db4")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/05f18bcb-1f58-4fb2-bbec-23b1ba834d60"
+					(reference "TP9")
 					(unit 1)
 				)
 			)

--- a/kicad/PMIC.kicad_sch
+++ b/kicad/PMIC.kicad_sch
@@ -5,6 +5,172 @@
 	(uuid "39cdc7fc-c9fc-4f55-9aa5-857fb78b482b")
 	(paper "A4")
 	(lib_symbols
+		(symbol "seven_lib:BAT54W"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "BAT54KFILM"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "seven-lib:D_SOD-523"
+				(at 0 -4.445 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://www.st.com/content/ccc/resource/technical/document/datasheet/07/50/54/f2/0d/ba/4a/79/CD00001322.pdf/files/CD00001322.pdf/jcr:content/translations/en.CD00001322.pdf"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Schottky barrier diode, SOT-323"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "schottky diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "SOT?323*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "BAT54W_0_1"
+				(polyline
+					(pts
+						(xy -1.905 0.635) (xy -1.905 1.27) (xy -1.27 1.27) (xy -1.27 -1.27) (xy -0.635 -1.27) (xy -0.635 -0.635)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 1.27) (xy 1.27 -1.27) (xy -1.27 0) (xy 1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "BAT54W_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin no_connect line
+					(at 0 0 90)
+					(length 2.54)
+					(hide yes)
+					(name "NC"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "seven_lib:C"
 			(pin_numbers
 				(hide yes)
@@ -621,6 +787,113 @@
 						)
 					)
 					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "seven_lib:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1445,7 +1718,7 @@
 		)
 		(uuid "51f26c50-08ef-44e9-ab68-71fc37ade594")
 	)
-	(text_box "NOTE: Connect to\nGND layer with a via.\nDo not short to GND\npad directly."
+	(text_box "Note: Connect to the GND layer using a via. Do not short directly to the GND pad."
 		(exclude_from_sim no)
 		(at 146.05 82.55 0)
 		(size 25.4 12.7)
@@ -1490,7 +1763,7 @@
 		)
 		(uuid "c3aca5d8-51f2-49fb-8847-4a8a1307d116")
 	)
-	(text_box "NOTE: C12 and C19 should be placed close to PVSS1 and PVSS2 pads respectively\n"
+	(text_box "Note: C12 and C19 should be placed close to the PVSS1 and PVSS2 pads, respectively."
 		(exclude_from_sim no)
 		(at 115.57 30.48 0)
 		(size 25.4 12.7)
@@ -1526,6 +1799,12 @@
 		(uuid "057b29b9-7259-44f3-a330-2949a51f5d78")
 	)
 	(junction
+		(at 36.83 69.85)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "18cf9d8b-718b-4476-9330-9822c2e6bb0e")
+	)
+	(junction
 		(at 146.05 113.03)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -1538,6 +1817,18 @@
 		(uuid "29edf386-ac5f-43c4-9492-ff9279d2c10a")
 	)
 	(junction
+		(at 130.81 85.09)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "29eeb4c7-e49d-42de-9454-9ed95a774626")
+	)
+	(junction
+		(at 142.24 97.79)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4ad1e80c-19c4-463a-af0b-6db2ff90feb0")
+	)
+	(junction
 		(at 127 105.41)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -1548,6 +1839,18 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "56c0f999-83d3-4f1e-a906-6f8b7722ba9b")
+	)
+	(junction
+		(at 142.24 113.03)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5e2fdf6e-09a8-4b13-9a8d-d90a420c9522")
+	)
+	(junction
+		(at 146.05 97.79)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "764418cf-b528-4fe0-9d4c-9f1976f1d81d")
 	)
 	(junction
 		(at 33.02 124.46)
@@ -1566,6 +1869,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "7d42cecd-5145-4054-a618-256db2990540")
+	)
+	(junction
+		(at 33.02 106.68)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "800a6fdb-50b3-4d34-8812-fdee3be42581")
 	)
 	(junction
 		(at 115.57 62.23)
@@ -1628,10 +1937,22 @@
 		(uuid "f337c961-5a2d-437c-bf95-2284fba1d534")
 	)
 	(junction
+		(at 35.56 118.11)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f712f667-4270-4abc-b6a7-bcad43ba9592")
+	)
+	(junction
 		(at 87.63 62.23)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "f72d5c64-632a-4704-b81c-e94d5a8aea7c")
+	)
+	(junction
+		(at 30.48 115.57)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8eb642f-0d40-4479-857b-3a111f767c8a")
 	)
 	(no_connect
 		(at 43.18 102.87)
@@ -1693,6 +2014,16 @@
 	)
 	(wire
 		(pts
+			(xy 30.48 115.57) (xy 43.18 115.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0cac2871-f541-43d6-b839-66d6d7aca15f")
+	)
+	(wire
+		(pts
 			(xy 33.02 123.19) (xy 33.02 124.46)
 		)
 		(stroke
@@ -1720,6 +2051,16 @@
 			(type default)
 		)
 		(uuid "174212b9-7f93-448e-8b5c-c282046753b6")
+	)
+	(wire
+		(pts
+			(xy 33.02 106.68) (xy 35.56 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "18b9de87-53ef-4633-a820-2b7c262b4708")
 	)
 	(wire
 		(pts
@@ -1753,7 +2094,7 @@
 	)
 	(wire
 		(pts
-			(xy 127 97.79) (xy 149.86 97.79)
+			(xy 127 97.79) (xy 142.24 97.79)
 		)
 		(stroke
 			(width 0)
@@ -1803,7 +2144,7 @@
 	)
 	(wire
 		(pts
-			(xy 114.3 113.03) (xy 146.05 113.03)
+			(xy 114.3 113.03) (xy 142.24 113.03)
 		)
 		(stroke
 			(width 0)
@@ -1820,6 +2161,16 @@
 			(type default)
 		)
 		(uuid "2e9e1574-10a8-4aef-80ea-f90b94a7aa01")
+	)
+	(wire
+		(pts
+			(xy 35.56 118.11) (xy 43.18 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "304b3432-83cf-4ab9-b395-466644f44ee3")
 	)
 	(wire
 		(pts
@@ -1843,13 +2194,33 @@
 	)
 	(wire
 		(pts
-			(xy 41.91 115.57) (xy 43.18 115.57)
+			(xy 26.67 115.57) (xy 30.48 115.57)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "374be733-6a05-43ae-8834-efabb7a9e770")
+	)
+	(wire
+		(pts
+			(xy 30.48 106.68) (xy 33.02 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3800d4af-ff52-442f-b420-84fe8fae3896")
+	)
+	(wire
+		(pts
+			(xy 142.24 113.03) (xy 146.05 113.03)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a3ab1e0-79f4-48d2-9dbc-872088d4c1df")
 	)
 	(wire
 		(pts
@@ -1863,6 +2234,26 @@
 	)
 	(wire
 		(pts
+			(xy 146.05 96.52) (xy 148.59 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b6ffd2a-6dc4-47a7-92ce-b797462b89eb")
+	)
+	(wire
+		(pts
+			(xy 36.83 69.85) (xy 43.18 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3ece70c6-dc85-4e96-b88c-780fd8b410ef")
+	)
+	(wire
+		(pts
 			(xy 96.52 62.23) (xy 101.6 62.23)
 		)
 		(stroke
@@ -1873,7 +2264,7 @@
 	)
 	(wire
 		(pts
-			(xy 41.91 118.11) (xy 43.18 118.11)
+			(xy 26.67 118.11) (xy 35.56 118.11)
 		)
 		(stroke
 			(width 0)
@@ -1890,6 +2281,16 @@
 			(type default)
 		)
 		(uuid "4c371e0d-f19b-432e-a619-480624898c10")
+	)
+	(wire
+		(pts
+			(xy 146.05 96.52) (xy 146.05 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5e0fff19-baaf-4a94-89cf-39fe8794673d")
 	)
 	(wire
 		(pts
@@ -1942,6 +2343,16 @@
 		)
 		(uuid "73ef3562-7cc9-4b1d-9017-184f35678c57")
 	)
+	(wire
+		(pts
+			(xy 153.67 104.14) (xy 153.67 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7626c4f6-10d4-4e04-9f0f-fa78cc4f4215")
+	)
 	(polyline
 		(pts
 			(xy 128.27 92.71) (xy 135.89 92.71)
@@ -1972,6 +2383,26 @@
 			(type default)
 		)
 		(uuid "7a3aa695-f3ef-405a-9528-89055fe16cc0")
+	)
+	(wire
+		(pts
+			(xy 142.24 97.79) (xy 146.05 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "83823a4a-c8c1-4db3-98d3-fe2b4718e5e4")
+	)
+	(wire
+		(pts
+			(xy 30.48 114.3) (xy 30.48 115.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "895b908e-db5f-477b-ad4a-cdce35db90e8")
 	)
 	(wire
 		(pts
@@ -2016,7 +2447,7 @@
 	)
 	(wire
 		(pts
-			(xy 127 85.09) (xy 132.08 85.09)
+			(xy 127 85.09) (xy 130.81 85.09)
 		)
 		(stroke
 			(width 0)
@@ -2076,6 +2507,16 @@
 	)
 	(wire
 		(pts
+			(xy 146.05 100.33) (xy 147.32 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aeab80fa-ba24-482c-8d89-902142d3822d")
+	)
+	(wire
+		(pts
 			(xy 76.2 49.53) (xy 76.2 57.15)
 		)
 		(stroke
@@ -2116,6 +2557,16 @@
 	)
 	(wire
 		(pts
+			(xy 146.05 97.79) (xy 146.05 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bac8d49b-7ff5-400b-8d28-fde9a218f721")
+	)
+	(wire
+		(pts
 			(xy 146.05 105.41) (xy 146.05 104.14)
 		)
 		(stroke
@@ -2147,7 +2598,17 @@
 	)
 	(wire
 		(pts
-			(xy 30.48 69.85) (xy 43.18 69.85)
+			(xy 33.02 104.14) (xy 33.02 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dcfd8f85-46aa-4c58-a5d0-bf1fe15bb185")
+	)
+	(wire
+		(pts
+			(xy 30.48 69.85) (xy 36.83 69.85)
 		)
 		(stroke
 			(width 0)
@@ -2164,6 +2625,16 @@
 			(type default)
 		)
 		(uuid "e0d78421-e57e-47bb-87d4-4719b59bb64c")
+	)
+	(wire
+		(pts
+			(xy 130.81 85.09) (xy 132.08 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e17a5d09-8810-4349-8a9d-6f450682b58a")
 	)
 	(wire
 		(pts
@@ -2207,6 +2678,16 @@
 	)
 	(wire
 		(pts
+			(xy 35.56 114.3) (xy 35.56 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f0cada9d-3240-472e-aa15-085c28e40169")
+	)
+	(wire
+		(pts
 			(xy 76.2 62.23) (xy 76.2 57.15)
 		)
 		(stroke
@@ -2214,6 +2695,16 @@
 			(type default)
 		)
 		(uuid "f5eb23f0-1569-4040-85d3-a0b121a1198a")
+	)
+	(wire
+		(pts
+			(xy 154.94 100.33) (xy 158.75 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f83d36df-ef30-434a-91b9-a5979daf4351")
 	)
 	(wire
 		(pts
@@ -2249,7 +2740,7 @@
 	)
 	(global_label "VDD_3V3"
 		(shape input)
-		(at 153.67 104.14 0)
+		(at 153.67 106.68 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -2257,9 +2748,31 @@
 			)
 			(justify left)
 		)
-		(uuid "571e1edc-956a-4069-a58e-52c9748bcede")
+		(uuid "40f19621-b8d9-4295-b2ad-ef6a9ed52f94")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 164.759 104.14 0)
+			(at 164.759 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD_1V8"
+		(shape input)
+		(at 33.02 104.14 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "dd5c8fd9-91c2-41a1-a2e7-6cb795050bde")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 33.02 93.051 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2293,7 +2806,7 @@
 	)
 	(hierarchical_label "VDD_3V3"
 		(shape output)
-		(at 149.86 97.79 0)
+		(at 148.59 96.52 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2326,7 +2839,7 @@
 	)
 	(hierarchical_label "SCL"
 		(shape input)
-		(at 41.91 118.11 180)
+		(at 26.67 118.11 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2337,7 +2850,7 @@
 	)
 	(hierarchical_label "SDA"
 		(shape bidirectional)
-		(at 41.91 115.57 180)
+		(at 26.67 115.57 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2345,6 +2858,84 @@
 			(justify right)
 		)
 		(uuid "ecb0644e-da18-4f97-b68c-1a8fbd9e630e")
+	)
+	(hierarchical_label "VDD_JTAG"
+		(shape output)
+		(at 158.75 100.33 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f63ed112-bced-4e47-9520-a0e156b482b5")
+	)
+	(symbol
+		(lib_id "seven_lib:R")
+		(at 30.48 110.49 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "046427cf-005a-4b4a-8425-3ae125967a79")
+		(property "Reference" "R17"
+			(at 28.448 110.744 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4k7"
+			(at 30.48 110.49 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:R_0402_1005Metric"
+			(at 32.258 110.49 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 30.48 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 30.48 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "042a7929-1b94-42e8-b3e1-ad4d8c028f3e")
+		)
+		(pin "2"
+			(uuid "de8a98a1-316b-4a57-8508-849694d59fd7")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cefcb938-0954-4d9a-a5b2-e2e651c202a6"
+					(reference "R17")
+					(unit 1)
+				)
+			)
+		)
 	)
 	(symbol
 		(lib_id "seven_lib:C")
@@ -3452,6 +4043,70 @@
 		)
 	)
 	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 142.24 113.03 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4e82e669-6869-4841-975d-b64fa3d91b44")
+		(property "Reference" "TP19"
+			(at 138.303 114.935 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "VDD_GNSS"
+			(at 138.303 117.475 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 137.16 113.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 137.16 113.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 142.24 113.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "85951946-e62d-4dd7-8c00-2b0f1ecede26")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cefcb938-0954-4d9a-a5b2-e2e651c202a6"
+					(reference "TP19")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "seven_lib:PWR_FLAG")
 		(at 149.86 62.23 180)
 		(unit 1)
@@ -3512,6 +4167,70 @@
 			(project ""
 				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cefcb938-0954-4d9a-a5b2-e2e651c202a6"
 					(reference "#FLG01")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 36.83 69.85 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5de51a44-962f-4ab7-9ebf-cf20e560d58f")
+		(property "Reference" "TP13"
+			(at 32.893 71.755 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "VDD_5V"
+			(at 32.893 74.295 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 31.75 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 31.75 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 36.83 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "41995823-e8ae-4d81-b6fb-8d89735d7a91")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cefcb938-0954-4d9a-a5b2-e2e651c202a6"
+					(reference "TP13")
 					(unit 1)
 				)
 			)
@@ -4726,6 +5445,206 @@
 		)
 	)
 	(symbol
+		(lib_id "seven_lib:BAT54W")
+		(at 151.13 100.33 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "dc88058d-8cb5-4f03-b04c-7ad8150266de")
+		(property "Reference" "D2"
+			(at 154.94 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "BAT54KFILM"
+			(at 146.558 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "seven-lib:D_SOD-523"
+			(at 151.13 95.885 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://www.st.com/content/ccc/resource/technical/document/datasheet/07/50/54/f2/0d/ba/4a/79/CD00001322.pdf/files/CD00001322.pdf/jcr:content/translations/en.CD00001322.pdf"
+			(at 151.13 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Schottky barrier diode, SOT-323"
+			(at 151.13 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "e7c60b9c-c5db-403d-841e-fc0132038141")
+		)
+		(pin "3"
+			(uuid "0d0bbeda-265c-4837-b575-8c14b68f3d62")
+		)
+		(pin "1"
+			(uuid "a5e89f27-b4c7-4c83-ae74-2b6e47910d67")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cefcb938-0954-4d9a-a5b2-e2e651c202a6"
+					(reference "D2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 130.81 85.09 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "de6a4fca-38c3-4489-987b-ff6da0c13bb2")
+		(property "Reference" "TP18"
+			(at 134.493 80.645 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "VDD_1V8"
+			(at 136.652 82.296 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 135.89 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 135.89 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 130.81 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f958839e-1ed9-456b-a9e1-92b708496836")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cefcb938-0954-4d9a-a5b2-e2e651c202a6"
+					(reference "TP18")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 142.24 97.79 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e91abf49-3ff6-4a43-bfc3-4a73c0bc794b")
+		(property "Reference" "TP20"
+			(at 138.303 99.695 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "VDD_3V3"
+			(at 138.303 102.235 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 137.16 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 137.16 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 142.24 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "afbfb266-62fe-4f66-9a30-69fb981e82c1")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cefcb938-0954-4d9a-a5b2-e2e651c202a6"
+					(reference "TP20")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "seven_lib:GND")
 		(at 135.89 54.61 180)
 		(unit 1)
@@ -4787,6 +5706,73 @@
 			(project "seven"
 				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cefcb938-0954-4d9a-a5b2-e2e651c202a6"
 					(reference "#PWR037")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:R")
+		(at 35.56 110.49 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f68832c3-4f20-4155-ba00-708e1030516b")
+		(property "Reference" "R18"
+			(at 33.528 110.744 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4k7"
+			(at 35.56 110.49 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:R_0402_1005Metric"
+			(at 37.338 110.49 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 35.56 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 35.56 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6f67a373-67ef-47c1-8d5c-c5f477672b44")
+		)
+		(pin "2"
+			(uuid "029c7223-c020-480f-be4c-e9efb7f35f25")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cefcb938-0954-4d9a-a5b2-e2e651c202a6"
+					(reference "R18")
 					(unit 1)
 				)
 			)

--- a/kicad/antenna_GNSS.kicad_sch
+++ b/kicad/antenna_GNSS.kicad_sch
@@ -881,7 +881,7 @@
 		)
 		(uuid "5e4dbbec-c0dd-4027-9237-a3b861b5bb19")
 	)
-	(text_box "NOTE: TRACE SHOULD BE 50Ω IMPEDANCE\n"
+	(text_box "Note: The trace should have a characteristic impedance of 50 Ω."
 		(exclude_from_sim no)
 		(at 101.6 102.87 0)
 		(size 25.4 12.7)
@@ -902,30 +902,7 @@
 			)
 			(justify left top)
 		)
-		(uuid "7a73f9e8-d3b5-44be-b011-75a1a0770946")
-	)
-	(text_box "NOTE: Place close to nRF9151"
-		(exclude_from_sim no)
-		(at 114.3 63.5 0)
-		(size 25.4 12.7)
-		(margins 0.9525 0.9525 0.9525 0.9525)
-		(stroke
-			(width 0)
-			(type solid)
-			(color 255 0 0 1)
-		)
-		(fill
-			(type color)
-			(color 255 67 78 1)
-		)
-		(effects
-			(font
-				(size 1.27 1.27)
-				(color 0 0 0 1)
-			)
-			(justify left top)
-		)
-		(uuid "d6c53920-da65-4e2b-9fcf-9b176df88668")
+		(uuid "9fede013-53a6-4252-971e-4bb57df6a306")
 	)
 	(text_box "Circuit Description\n"
 		(exclude_from_sim no)
@@ -948,6 +925,29 @@
 			(justify left top)
 		)
 		(uuid "ea4fc73a-92ed-491c-aefb-813db3608b76")
+	)
+	(text_box "Note: Place SMA close to the nRF9151."
+		(exclude_from_sim no)
+		(at 134.62 64.77 0)
+		(size 25.4 12.7)
+		(margins 0.9525 0.9525 0.9525 0.9525)
+		(stroke
+			(width 0)
+			(type solid)
+			(color 255 0 0 1)
+		)
+		(fill
+			(type color)
+			(color 255 67 78 1)
+		)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(color 0 0 0 1)
+			)
+			(justify left top)
+		)
+		(uuid "fde39f9f-6126-44a5-8bc9-9c6fd0365ba7")
 	)
 	(junction
 		(at 85.09 71.12)

--- a/kicad/antenna_LTE.kicad_sch
+++ b/kicad/antenna_LTE.kicad_sch
@@ -539,7 +539,7 @@
 		)
 		(uuid "11a7c834-ff98-4377-a15c-7a6fbbf38b83")
 	)
-	(text_box "NOTE: TRACE SHOULD BE 50Ω IMPEDANCE\n"
+	(text_box "Note: The trace should have a characteristic impedance of 50 Ω."
 		(exclude_from_sim no)
 		(at 95.25 104.14 0)
 		(size 25.4 12.7)
@@ -604,7 +604,7 @@
 		)
 		(uuid "5e4dbbec-c0dd-4027-9237-a3b861b5bb19")
 	)
-	(text_box "NOTE: Place close to nRF9151"
+	(text_box "Note: Place SMA close to the nRF9151."
 		(exclude_from_sim no)
 		(at 128.27 66.04 0)
 		(size 25.4 12.7)

--- a/kicad/buzzer.kicad_sch
+++ b/kicad/buzzer.kicad_sch
@@ -939,6 +939,113 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "seven_lib:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 	)
 	(text "\n\n"
 		(exclude_from_sim no)
@@ -1063,6 +1170,12 @@
 		(uuid "3877c963-e063-4090-8fd9-92294ddb9032")
 	)
 	(junction
+		(at 64.77 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "be5c652f-8e59-428f-bbcf-ab603262b366")
+	)
+	(junction
 		(at 85.09 69.85)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -1080,13 +1193,23 @@
 	)
 	(wire
 		(pts
-			(xy 59.69 101.6) (xy 67.31 101.6)
+			(xy 59.69 101.6) (xy 64.77 101.6)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "29a9262d-5990-4472-bdec-d1db9cd30114")
+	)
+	(wire
+		(pts
+			(xy 64.77 104.14) (xy 64.77 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "314b0949-8008-4844-aacb-2a4ad0dfed89")
 	)
 	(wire
 		(pts
@@ -1107,6 +1230,16 @@
 			(type dash)
 		)
 		(uuid "3e61f56f-4410-4228-8461-89ae442f3060")
+	)
+	(wire
+		(pts
+			(xy 64.77 101.6) (xy 67.31 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5edb3636-b05b-42b4-b4b8-aa477d371de1")
 	)
 	(wire
 		(pts
@@ -1464,6 +1597,70 @@
 			(project ""
 				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/3959a5c9-da67-4dbd-8c3b-230c0962e71e"
 					(reference "R3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 64.77 104.14 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "84c670e7-8983-45ea-9afe-f2ae1986dd26")
+		(property "Reference" "TP12"
+			(at 60.833 106.045 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "BUZZER"
+			(at 60.833 108.585 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 59.69 104.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 59.69 104.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 64.77 104.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2d3c77f0-96eb-4343-bc56-7ce8cd55a429")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/3959a5c9-da67-4dbd-8c3b-230c0962e71e"
+					(reference "TP12")
 					(unit 1)
 				)
 			)

--- a/kicad/fp-lib/seven-fp.pretty/TestPoint_Pad_2.0x2.0mm.kicad_mod
+++ b/kicad/fp-lib/seven-fp.pretty/TestPoint_Pad_2.0x2.0mm.kicad_mod
@@ -1,0 +1,155 @@
+(footprint "TestPoint_Pad_2.0x2.0mm"
+	(version 20241229)
+	(generator "pcbnew")
+	(generator_version "9.0")
+	(layer "F.Cu")
+	(descr "SMD rectangular pad as test Point, square 2.0mm side length")
+	(tags "test point SMD pad rectangle square")
+	(property "Reference" "REF**"
+		(at 0 -1.998 0)
+		(layer "F.SilkS")
+		(uuid "c28ddd99-5711-44a3-a273-99758422503e")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Value" "TestPoint_Pad_2.0x2.0mm"
+		(at 0 2.05 0)
+		(layer "F.Fab")
+		(uuid "9aa69a93-282f-4dbc-aa50-bc2d2bffe762")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Datasheet" ""
+		(at 0 0 0)
+		(unlocked yes)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "9fdb7435-a60e-4d0f-8580-b9b7947da223")
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Description" ""
+		(at 0 0 0)
+		(unlocked yes)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "d48451bc-d59c-4d07-81dc-563e2647e3da")
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.15)
+			)
+		)
+	)
+	(attr exclude_from_pos_files exclude_from_bom)
+	(fp_line
+		(start -1.2 -1.2)
+		(end 1.2 -1.2)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "e902a282-18c3-405c-a440-66a17161dac7")
+	)
+	(fp_line
+		(start -1.2 1.2)
+		(end -1.2 -1.2)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "48cecfff-2774-4bd4-82ef-45f3ae83fa29")
+	)
+	(fp_line
+		(start 1.2 -1.2)
+		(end 1.2 1.2)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "f52b073b-c5f9-44f2-9062-2efbec7f39d3")
+	)
+	(fp_line
+		(start 1.2 1.2)
+		(end -1.2 1.2)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "3a3fe700-18c3-472f-ab8b-2c990ff31a03")
+	)
+	(fp_line
+		(start -1.5 -1.5)
+		(end -1.5 1.5)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "d0d7b530-c881-455f-8e39-737d742d1e00")
+	)
+	(fp_line
+		(start -1.5 -1.5)
+		(end 1.5 -1.5)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "bbf4bf51-4c66-40e9-add4-4dbab34c228e")
+	)
+	(fp_line
+		(start 1.5 1.5)
+		(end -1.5 1.5)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "0fc189fc-7992-4543-87d4-0049300ab7c5")
+	)
+	(fp_line
+		(start 1.5 1.5)
+		(end 1.5 -1.5)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "b515fb22-bc3f-4c69-b4d5-094158607301")
+	)
+	(fp_text user "${REFERENCE}"
+		(at 0 -2 0)
+		(layer "F.Fab")
+		(uuid "4639fd02-057a-4b13-94ac-0df1b7fe9f0a")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(pad "1" smd rect
+		(at 0 0)
+		(size 2 2)
+		(layers "F.Cu" "F.Mask")
+		(uuid "fe8ce89d-a8a3-4dc0-8bc8-0e7ade183b61")
+	)
+	(embedded_fonts no)
+)

--- a/kicad/mcu.kicad_sch
+++ b/kicad/mcu.kicad_sch
@@ -819,6 +819,113 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "seven_lib:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "seven_lib:nRF9151-LAXX"
 			(exclude_from_sim no)
 			(in_bom yes)
@@ -2998,81 +3105,17 @@
 	)
 	(text "\n\n"
 		(exclude_from_sim no)
-		(at 228.6 85.09 0)
+		(at 227.33 85.09 0)
 		(effects
 			(font
 				(size 4.572 4.572)
 			)
 		)
-		(uuid "86b72729-c100-434e-8606-178816cd864a")
-	)
-	(text_box "Component Description\n"
-		(exclude_from_sim no)
-		(at 177.546 77.47 0)
-		(size 107.95 7.62)
-		(margins 0.9525 0.9525 0.9525 0.9525)
-		(stroke
-			(width 0)
-			(type dash)
-		)
-		(fill
-			(type none)
-		)
-		(effects
-			(font
-				(size 3.81 3.81)
-				(thickness 0.762)
-				(bold yes)
-			)
-			(justify top)
-		)
-		(uuid "3237a112-3de6-42ba-b72d-768314ae0340")
-	)
-	(text_box "nRF9151 MCU\n"
-		(exclude_from_sim no)
-		(at 177.546 12.7 0)
-		(size 40.64 11.43)
-		(margins 0.9525 0.9525 0.9525 0.9525)
-		(stroke
-			(width 0)
-			(type dash)
-		)
-		(fill
-			(type none)
-		)
-		(effects
-			(font
-				(size 2.54 2.54)
-				(thickness 0.508)
-				(bold yes)
-			)
-			(justify left top)
-		)
-		(uuid "38e3a6ac-c58d-4ed3-a473-e9e81a393f14")
-	)
-	(text_box "U1 - nRF9151\n\nCellular IoT System-in-Package (SiP)\n\nIntegrated LTE-M / NB-IoT modem\n\nIntegrated GNSS receiver\n\nArm Cortex-M33 MCU\n\nIntegrated RF front end and baseband\n\nMultiple digital interfaces (UART, SPI, I²C)\n\nProgrammable GPIOs\n\nIntegrated power management"
-		(exclude_from_sim no)
-		(at 177.546 85.09 0)
-		(size 107.95 80.01)
-		(margins 0.9525 0.9525 0.9525 0.9525)
-		(stroke
-			(width 0)
-			(type dash)
-		)
-		(fill
-			(type none)
-		)
-		(effects
-			(font
-				(size 2.54 2.54)
-			)
-			(justify left top)
-		)
-		(uuid "3f844faa-611e-4730-add7-459ab4f174ec")
+		(uuid "3f1b9f9c-a1e2-45a3-b614-4ff07e51e089")
 	)
 	(text_box "Circuit Description\n"
 		(exclude_from_sim no)
-		(at 218.186 12.7 0)
+		(at 216.916 12.7 0)
 		(size 67.31 11.43)
 		(margins 0.9525 0.9525 0.9525 0.9525)
 		(stroke
@@ -3090,11 +3133,99 @@
 			)
 			(justify left top)
 		)
-		(uuid "43126efd-cd00-4b55-b753-0707cfb331f1")
+		(uuid "32342575-d0fa-4e04-a849-ada508c84744")
 	)
-	(text_box "This circuit contains the nRF9151 cellular IoT MCU/module and its required support components. The device is powered from the board supply (5V), with the MCU I/O domain using GPIO_VDD = 1.8 V. The schematic includes the basic power filtering and decoupling."
+	(text_box "Component Description\n"
 		(exclude_from_sim no)
-		(at 177.546 24.13 0)
+		(at 176.276 77.47 0)
+		(size 107.95 7.62)
+		(margins 0.9525 0.9525 0.9525 0.9525)
+		(stroke
+			(width 0)
+			(type dash)
+		)
+		(fill
+			(type none)
+		)
+		(effects
+			(font
+				(size 3.81 3.81)
+				(thickness 0.762)
+				(bold yes)
+			)
+			(justify top)
+		)
+		(uuid "3a377fc8-65ff-47ab-8f7c-838a1ff56837")
+	)
+	(text_box "U1 - nRF9151\n\nCellular IoT System-in-Package (SiP)\n\nIntegrated LTE-M / NB-IoT modem\n\nIntegrated GNSS receiver\n\nArm Cortex-M33 MCU\n\nIntegrated RF front end and baseband\n\nMultiple digital interfaces (UART, SPI, I²C)\n\nProgrammable GPIOs\n\nIntegrated power management"
+		(exclude_from_sim no)
+		(at 176.276 85.09 0)
+		(size 107.95 80.01)
+		(margins 0.9525 0.9525 0.9525 0.9525)
+		(stroke
+			(width 0)
+			(type dash)
+		)
+		(fill
+			(type none)
+		)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left top)
+		)
+		(uuid "8f74614b-e0a2-4f7f-9813-75057f95978d")
+	)
+	(text_box "Note: All GND pins from the MCU are hidden and connected to this GND pin. For more information about the pins, click on this note."
+		(exclude_from_sim no)
+		(at 29.21 176.53 0)
+		(size 25.4 19.05)
+		(margins 0.9525 0.9525 0.9525 0.9525)
+		(stroke
+			(width 0)
+			(type solid)
+			(color 255 0 0 1)
+		)
+		(fill
+			(type color)
+			(color 255 67 78 1)
+		)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(color 0 0 0 1)
+			)
+			(justify left top)
+			(href "https://docs.nordicsemi.com/bundle/ps_nrf9151/page/pin.html")
+		)
+		(uuid "966aebf8-37c9-49f2-88c2-b57a2301cd6c")
+	)
+	(text_box "nRF9151 MCU\n"
+		(exclude_from_sim no)
+		(at 176.276 12.7 0)
+		(size 40.64 11.43)
+		(margins 0.9525 0.9525 0.9525 0.9525)
+		(stroke
+			(width 0)
+			(type dash)
+		)
+		(fill
+			(type none)
+		)
+		(effects
+			(font
+				(size 2.54 2.54)
+				(thickness 0.508)
+				(bold yes)
+			)
+			(justify left top)
+		)
+		(uuid "cb037eff-df98-4274-b50c-5c7ca07b935c")
+	)
+	(text_box "This circuit contains the nRF9151 cellular IoT MCU/module and its required support components. The device is powered from the board supply (5 V). The MCU I/O domain is configurable via a jumper for hot swapping, with GPIO_VDD set to either 1.8 V or 3.3 V (default = 3.3 V). The schematic includes basic power filtering and decoupling."
+		(exclude_from_sim no)
+		(at 176.276 24.13 0)
 		(size 107.95 53.34)
 		(margins 0.9525 0.9525 0.9525 0.9525)
 		(stroke
@@ -3110,11 +3241,11 @@
 			)
 			(justify left top)
 		)
-		(uuid "f8283ce3-6c19-4a97-aa05-fd875b95029f")
+		(uuid "cd36ce0b-94ac-44fa-b316-4f4842a809a1")
 	)
-	(text_box "NOTE: Avoid placing MCU near noisy components like buck or high-frequency signals"
+	(text_box "Note: Avoid placing the MCU near noisy components such as buck converters or high-frequency signals."
 		(exclude_from_sim no)
-		(at 146.05 72.39 0)
+		(at 144.78 77.47 0)
 		(size 25.4 12.7)
 		(margins 0.9525 0.9525 0.9525 0.9525)
 		(stroke
@@ -3133,847 +3264,999 @@
 			)
 			(justify left top)
 		)
-		(uuid "faa12035-1cfe-43fa-a8a5-f4097417a1f3")
+		(uuid "cec19a1f-0edd-45d9-9635-984dfe2d0ef2")
 	)
 	(junction
-		(at 45.72 20.32)
+		(at 88.9 19.05)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "06d6c830-1fbb-4a1b-94a2-e9a5c12b9ab0")
+		(uuid "0deea1d8-7fd4-4a4d-9e9c-2cd0d76e24dc")
 	)
 	(junction
-		(at 99.06 20.32)
+		(at 88.9 36.83)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "2b84ef25-f5d5-45bf-acca-d438840f9b5f")
+		(uuid "1bb43ecf-06e9-4e52-a4d4-a4bd4116f665")
 	)
 	(junction
-		(at 128.27 20.32)
+		(at 114.3 25.4)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "66dc5188-3e95-4c62-b607-c8aaba1b8bbf")
+		(uuid "1c44ab6f-a44f-4f0a-ad93-33fb47b6dd23")
 	)
 	(junction
-		(at 31.75 20.32)
+		(at 88.9 33.02)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "c9e56b6c-404e-493a-ba05-1fc0149baf52")
+		(uuid "2127fabf-f932-4292-bc68-cc16d65721d7")
 	)
 	(junction
-		(at 115.57 20.32)
+		(at 105.41 25.4)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "cef0c964-3007-4d75-8c23-edb99376b44d")
+		(uuid "27eecfee-7c2c-424f-827c-ec3f9b98240c")
 	)
 	(junction
-		(at 90.17 30.48)
+		(at 69.85 19.05)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "d8e7e93a-3c32-4501-ab84-e09941086011")
+		(uuid "328b7c22-7818-4fd1-a6ef-097ee244ecac")
 	)
 	(junction
-		(at 88.9 20.32)
+		(at 142.24 152.4)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "e1e2db61-a856-48b5-85dd-d27e04530b7d")
+		(uuid "3ddb5204-9060-41a1-806d-e2449ef0b955")
 	)
 	(junction
-		(at 72.39 20.32)
+		(at 95.25 25.4)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "f4c69e23-2819-474d-83e6-0991f2ebf3be")
+		(uuid "4f1094e5-10b2-44b5-9d67-315e55b3adb7")
 	)
 	(junction
-		(at 59.69 20.32)
+		(at 91.44 186.69)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "f9381f37-2ccf-446a-8d28-815deb264d3c")
+		(uuid "6ce1558f-4a2d-4269-8c0e-24c29db303ae")
+	)
+	(junction
+		(at 43.18 19.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "796fb5f6-e754-4eb5-b0e2-3896e864cd68")
+	)
+	(junction
+		(at 39.37 116.84)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d832740-93bb-4764-9e65-126c001b082c")
+	)
+	(junction
+		(at 29.21 19.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9381128c-de66-4175-bef9-7ebbeabff19b")
+	)
+	(junction
+		(at 134.62 152.4)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf6fa072-3e9a-4b28-9283-7f1337e9ba74")
+	)
+	(junction
+		(at 39.37 114.3)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d25408ae-a81b-4fbf-962e-84dbd7ed8245")
+	)
+	(junction
+		(at 127 25.4)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e2a52422-e708-4e36-b242-10ba8172b962")
+	)
+	(junction
+		(at 57.15 19.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f69aa1d0-1747-4c70-94af-a1d7cce8ebc2")
 	)
 	(no_connect
-		(at 59.69 134.62)
-		(uuid "3560b650-030f-4d26-a3d1-8f205ce0846c")
+		(at 58.42 167.64)
+		(uuid "04bee0f1-58cc-466e-bc13-827408609715")
 	)
 	(no_connect
-		(at 59.69 165.1)
-		(uuid "5e1c1d8e-fb4b-46c8-830d-2844af422c82")
+		(at 124.46 139.7)
+		(uuid "09d2df43-8fb5-4b3f-8a66-d57f4d9628e1")
 	)
 	(no_connect
-		(at 125.73 121.92)
-		(uuid "62243038-657f-4c6d-823d-230347606bd6")
+		(at 58.42 160.02)
+		(uuid "1534fa39-3da5-480d-b090-f27b36ee1911")
 	)
 	(no_connect
-		(at 59.69 162.56)
-		(uuid "6b7a2282-1c4d-4ad3-9921-5457bc871351")
+		(at 124.46 76.2)
+		(uuid "28e822a0-dc2f-4f12-b3d5-82b07580bbcc")
 	)
 	(no_connect
-		(at 125.73 71.12)
-		(uuid "732c5e5a-bc80-4de9-a46b-626e3f0e5451")
+		(at 124.46 142.24)
+		(uuid "3e0804e8-d0e1-4f2b-b143-93ade7b19d58")
 	)
 	(no_connect
-		(at 59.69 154.94)
-		(uuid "92428171-8333-47ef-ad84-260e9b9e02ae")
+		(at 58.42 137.16)
+		(uuid "4c6b6b43-d870-4e02-8241-9488924da706")
 	)
 	(no_connect
-		(at 59.69 106.68)
-		(uuid "9ed8efac-0447-4111-94d9-16337f03bc26")
+		(at 58.42 142.24)
+		(uuid "5e80a1b4-b26f-4016-8ea3-e5043f8550c4")
 	)
 	(no_connect
-		(at 59.69 167.64)
-		(uuid "a444cb66-07f2-4012-aa6d-c0f72dd7aae3")
+		(at 58.42 139.7)
+		(uuid "87017fba-45f4-4cac-bd4f-c3c5516dcacc")
 	)
 	(no_connect
-		(at 125.73 116.84)
-		(uuid "a5ee8599-a4e5-4534-a288-8b4fffff4467")
+		(at 124.46 124.46)
+		(uuid "aa64b7be-5e2a-4f26-9871-615a5776d825")
 	)
 	(no_connect
-		(at 59.69 132.08)
-		(uuid "ccd5c0e2-8dad-4669-a88d-a8dadd0cebf8")
+		(at 124.46 144.78)
+		(uuid "d2a0ed73-9b0f-45fa-bcf5-5c3aaf041c16")
 	)
 	(no_connect
-		(at 125.73 119.38)
-		(uuid "d3a67312-c28f-46ec-8eac-53127e5a771b")
+		(at 124.46 127)
+		(uuid "f769644e-f472-4cda-b578-6a75147fe8b1")
 	)
 	(no_connect
-		(at 125.73 134.62)
-		(uuid "da2011ba-0655-49d8-84b7-46bf3c6350a5")
+		(at 58.42 170.18)
+		(uuid "fd394455-198e-4229-8991-c6bee69b47d4")
 	)
 	(no_connect
-		(at 59.69 137.16)
-		(uuid "e3d87b5e-8185-4e14-b766-6abe0b5b082c")
+		(at 58.42 172.72)
+		(uuid "fff3ec15-54f4-4dfe-841a-897cceb280f3")
 	)
 	(wire
 		(pts
-			(xy 59.69 21.59) (xy 59.69 20.32)
+			(xy 147.32 25.4) (xy 127 25.4)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "00369c89-7510-40ba-b181-aa417c979f8f")
+		(uuid "06e32f45-eb85-4876-8ddc-84e848d44912")
 	)
 	(wire
 		(pts
-			(xy 134.62 48.26) (xy 137.16 48.26)
+			(xy 39.37 114.3) (xy 58.42 114.3)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "02670883-8ff9-4617-87c7-a01bd40b515a")
+		(uuid "0b0eb826-c2ae-4190-8861-094bf53de781")
 	)
 	(wire
 		(pts
-			(xy 127 147.32) (xy 125.73 147.32)
+			(xy 29.21 19.05) (xy 43.18 19.05)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "09209d7c-6915-41b3-a61a-80e00b4cbef8")
+		(uuid "0fe60c9c-0f97-4462-879b-89b8a6c2b08e")
 	)
 	(wire
 		(pts
-			(xy 49.53 48.26) (xy 50.8 48.26)
+			(xy 124.46 152.4) (xy 134.62 152.4)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "0c5b6622-86f9-4031-912f-ef9a31fbf648")
+		(uuid "113d8e2e-f797-49a8-b3c9-4ce05ca20959")
 	)
 	(wire
 		(pts
-			(xy 127 139.7) (xy 125.73 139.7)
+			(xy 29.21 19.05) (xy 29.21 20.32)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "0f4f4354-6920-4420-a16a-c7137e1ee483")
+		(uuid "187d5eaa-6b2f-4495-9055-d0f4f450f79b")
 	)
 	(wire
 		(pts
-			(xy 58.42 152.4) (xy 59.69 152.4)
+			(xy 57.15 68.58) (xy 58.42 68.58)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "0f7ff164-e1b8-439c-b62d-41c833809224")
+		(uuid "19daebfa-b65b-46e3-9400-b31a561b56c9")
 	)
 	(wire
 		(pts
-			(xy 88.9 30.48) (xy 90.17 30.48)
+			(xy 39.37 116.84) (xy 58.42 116.84)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "10ae58cf-d482-424e-995d-5f48bcb6f77c")
+		(uuid "1efdb560-8e02-4e75-b8aa-8bfaa97c003e")
 	)
 	(wire
 		(pts
-			(xy 59.69 20.32) (xy 62.23 20.32)
+			(xy 57.15 78.74) (xy 58.42 78.74)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1209888d-b8c7-4252-bead-96ddfd2e0ce7")
+		(uuid "20ad3020-f155-4096-8d87-db4eeb0e22c9")
 	)
 	(wire
 		(pts
-			(xy 58.42 99.06) (xy 59.69 99.06)
+			(xy 57.15 111.76) (xy 58.42 111.76)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "132b3710-9741-4e5c-afcb-6b101df545b9")
+		(uuid "251cd1c7-38f0-49ff-a3eb-05a7e9b2aae1")
 	)
 	(wire
 		(pts
-			(xy 127 68.58) (xy 125.73 68.58)
+			(xy 142.24 152.4) (xy 148.59 152.4)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "14e13b3b-1a6f-45f9-a01a-3f6e89763f4d")
+		(uuid "2e70ee04-a6cb-4c88-bfd6-040c4b651fa0")
 	)
 	(wire
 		(pts
-			(xy 125.73 48.26) (xy 127 48.26)
+			(xy 133.35 53.34) (xy 135.89 53.34)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1546a3d6-288d-4fd7-a857-303bafbcbc63")
+		(uuid "314f2a7b-e00e-4b3d-9926-4812bea83fd4")
 	)
 	(wire
 		(pts
-			(xy 97.79 31.75) (xy 97.79 33.02)
+			(xy 36.83 116.84) (xy 39.37 116.84)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1572b6a3-8f6b-420d-a2e9-57ca67938108")
+		(uuid "31f79a3a-59f2-429e-9f9c-bb34489f6809")
 	)
 	(wire
 		(pts
-			(xy 127 111.76) (xy 125.73 111.76)
+			(xy 157.48 152.4) (xy 156.21 152.4)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "17c149ce-a979-4738-9f08-ff89ef077f8c")
+		(uuid "339f514d-9a19-46c0-a788-83af83ecb4b0")
 	)
 	(wire
 		(pts
-			(xy 31.75 20.32) (xy 45.72 20.32)
+			(xy 151.13 25.4) (xy 151.13 27.94)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1c0285b7-bea8-4f0e-8784-d02699cded32")
+		(uuid "3778031c-349c-49b8-8372-305e38cbfded")
 	)
 	(wire
 		(pts
-			(xy 58.42 96.52) (xy 59.69 96.52)
+			(xy 91.44 25.4) (xy 91.44 38.1)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "25e620d7-31b2-4d22-9217-681c3645c588")
+		(uuid "3b85c632-6900-41e1-9202-411069e3be2e")
 	)
 	(wire
 		(pts
-			(xy 92.71 20.32) (xy 92.71 33.02)
+			(xy 91.44 185.42) (xy 91.44 186.69)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "26a9c173-a85d-4960-8c9b-bdae99729b66")
+		(uuid "3f3ed1a0-c437-43b1-b0ac-cf3a330cbf55")
 	)
 	(wire
 		(pts
-			(xy 58.42 147.32) (xy 59.69 147.32)
+			(xy 57.15 106.68) (xy 58.42 106.68)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "2744a104-76b6-4044-8c63-b4b3a9bd584f")
+		(uuid "41b6ca5a-1729-4a7e-b874-78694ab4f963")
 	)
 	(wire
 		(pts
-			(xy 58.42 66.04) (xy 59.69 66.04)
+			(xy 57.15 152.4) (xy 58.42 152.4)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "293299c6-dd84-4f22-954a-7fed7acad454")
-	)
-	(wire
-		(pts
-			(xy 58.42 121.92) (xy 59.69 121.92)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "298176ac-2665-4f12-a16c-9d2ebfad3e65")
-	)
-	(wire
-		(pts
-			(xy 58.42 111.76) (xy 59.69 111.76)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2e6ac6a9-75b9-4a8c-815d-ed1d01cce760")
-	)
-	(wire
-		(pts
-			(xy 58.42 48.26) (xy 59.69 48.26)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "361f89fe-24d2-4692-9f40-e6264b8153e0")
-	)
-	(wire
-		(pts
-			(xy 92.71 20.32) (xy 99.06 20.32)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3c91e373-810c-4843-8bd9-e5f1de1662e7")
-	)
-	(wire
-		(pts
-			(xy 58.42 78.74) (xy 59.69 78.74)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "43d0f0b6-a118-446f-9c57-783129d96b88")
-	)
-	(wire
-		(pts
-			(xy 128.27 21.59) (xy 128.27 20.32)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "47582840-07fd-4477-888f-c73877b95328")
-	)
-	(wire
-		(pts
-			(xy 58.42 104.14) (xy 59.69 104.14)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "4c9724d6-9df5-4e70-bc4e-db468431d00e")
-	)
-	(wire
-		(pts
-			(xy 88.9 20.32) (xy 90.17 20.32)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "4e825783-187f-4e03-984a-575c749fb681")
-	)
-	(wire
-		(pts
-			(xy 45.72 21.59) (xy 45.72 20.32)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "54a5216e-e91a-4030-9016-62569eddf6e2")
-	)
-	(wire
-		(pts
-			(xy 127 154.94) (xy 125.73 154.94)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "57205741-fdf9-4a18-bf34-c0aee742cca5")
-	)
-	(wire
-		(pts
-			(xy 58.42 114.3) (xy 59.69 114.3)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "57b2cd92-88e2-483e-8f0b-7554db5ad23d")
-	)
-	(wire
-		(pts
-			(xy 58.42 71.12) (xy 59.69 71.12)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "5973b7ec-1157-40ee-8259-5d0383fe03e0")
-	)
-	(wire
-		(pts
-			(xy 58.42 63.5) (xy 59.69 63.5)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6146c93f-3a8d-4d57-8e63-dbdbe3e2fccb")
-	)
-	(wire
-		(pts
-			(xy 27.94 20.32) (xy 31.75 20.32)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6903905d-7187-403a-925b-93b8ead5e4ca")
-	)
-	(wire
-		(pts
-			(xy 152.4 38.1) (xy 152.4 35.56)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6cb632f5-9e5b-465b-9f9d-29735f6e7a10")
-	)
-	(wire
-		(pts
-			(xy 99.06 20.32) (xy 115.57 20.32)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "72d2d6dd-8647-45fb-86c6-4632a41b5d57")
-	)
-	(wire
-		(pts
-			(xy 90.17 20.32) (xy 90.17 30.48)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "80cb5cea-8f12-4bc5-b811-fcac4f57a34d")
-	)
-	(wire
-		(pts
-			(xy 58.42 119.38) (xy 59.69 119.38)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "83c5234e-7f58-4bc3-ba45-dda4a10aff90")
-	)
-	(wire
-		(pts
-			(xy 157.48 38.1) (xy 152.4 38.1)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "893614bf-97a1-448e-b6cd-4bc8f7ecfa3d")
-	)
-	(wire
-		(pts
-			(xy 58.42 91.44) (xy 59.69 91.44)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "8b944bab-9e8f-4118-a509-f419ac81f59f")
-	)
-	(wire
-		(pts
-			(xy 58.42 73.66) (xy 59.69 73.66)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "8c82ee69-222c-4aec-8724-30652d3b8ea9")
-	)
-	(wire
-		(pts
-			(xy 58.42 101.6) (xy 59.69 101.6)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "8dd8fcbb-561c-4027-9281-dddc60e9055f")
-	)
-	(wire
-		(pts
-			(xy 58.42 60.96) (xy 59.69 60.96)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "8e4b1522-209b-4086-bcb3-77b249a1f0b3")
-	)
-	(wire
-		(pts
-			(xy 58.42 83.82) (xy 59.69 83.82)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "915ff4f3-81d1-4840-9012-3b9725747bcd")
-	)
-	(wire
-		(pts
-			(xy 58.42 55.88) (xy 59.69 55.88)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "95076021-6f33-41f7-9cdf-1498fa0de978")
-	)
-	(wire
-		(pts
-			(xy 152.4 20.32) (xy 152.4 22.86)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "963457f7-9ca3-4db9-b72f-9e14a0e1a336")
-	)
-	(wire
-		(pts
-			(xy 72.39 21.59) (xy 72.39 20.32)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a6e298ea-75db-495b-8ca0-efe6e7a4ac15")
-	)
-	(wire
-		(pts
-			(xy 148.59 20.32) (xy 128.27 20.32)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "aa3c0880-07f8-46a6-94ed-3fef6f2da038")
-	)
-	(wire
-		(pts
-			(xy 127 91.44) (xy 125.73 91.44)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "aa46f51f-afdf-4a33-ab34-6193cb7e2480")
-	)
-	(wire
-		(pts
-			(xy 92.71 180.34) (xy 92.71 182.88)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b11fad79-ed9d-45cc-8cd5-4a0e856ce485")
-	)
-	(wire
-		(pts
-			(xy 115.57 20.32) (xy 128.27 20.32)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b3d4a5c7-3ff4-43b4-be21-6e2a8240fca6")
-	)
-	(wire
-		(pts
-			(xy 58.42 68.58) (xy 59.69 68.58)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b48b570c-c731-4d77-83f1-858733162d62")
-	)
-	(wire
-		(pts
-			(xy 58.42 149.86) (xy 59.69 149.86)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b56f4714-9964-4e21-bad5-8dcaf306913c")
-	)
-	(wire
-		(pts
-			(xy 58.42 109.22) (xy 59.69 109.22)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b6438bcc-29b2-4782-b4fe-23d383682b7c")
-	)
-	(wire
-		(pts
-			(xy 127 152.4) (xy 125.73 152.4)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b8ec9d47-b49b-4e44-b282-ff63062f8d99")
+		(uuid "4b23acf0-0700-45b8-a663-9ee8c348138b")
 	)
 	(polyline
 		(pts
-			(xy 177.546 77.47) (xy 285.496 77.47)
+			(xy 54.61 187.96) (xy 91.44 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4d4edb47-bbce-482e-9c21-7cde099efa69")
+	)
+	(wire
+		(pts
+			(xy 57.15 66.04) (xy 58.42 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5223390f-bc41-42c2-b680-79711fb75ac1")
+	)
+	(wire
+		(pts
+			(xy 57.15 53.34) (xy 58.42 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "52a4d0a8-cea2-41f1-b405-d602332d8608")
+	)
+	(wire
+		(pts
+			(xy 57.15 88.9) (xy 58.42 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "54eaaa7a-d80c-4c41-9c7c-06757dd0607d")
+	)
+	(wire
+		(pts
+			(xy 125.73 116.84) (xy 124.46 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c0fa032-1fed-4d1a-8533-a391046c519e")
+	)
+	(wire
+		(pts
+			(xy 125.73 160.02) (xy 124.46 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5cf4a7f0-46af-4f8c-b7e9-2546f103f126")
+	)
+	(wire
+		(pts
+			(xy 124.46 53.34) (xy 125.73 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d1dda56-b729-4ddb-a163-75071e2760a9")
+	)
+	(wire
+		(pts
+			(xy 142.24 161.29) (xy 142.24 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5e2911a8-1d34-42e1-97ff-425e9d4fb89b")
+	)
+	(wire
+		(pts
+			(xy 57.15 91.44) (xy 58.42 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f25bd60-cd0f-4bc0-b947-721eecd8e330")
+	)
+	(wire
+		(pts
+			(xy 57.15 86.36) (xy 58.42 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60e970f2-27d0-4957-89a9-77f2db9a3769")
+	)
+	(polyline
+		(pts
+			(xy 176.276 77.47) (xy 284.226 77.47)
 		)
 		(stroke
 			(width 0)
 			(type dash)
 		)
-		(uuid "b9c946c4-a4be-41c2-ae79-fe854499158d")
+		(uuid "61d1ad4e-4ed5-4c7d-a3c8-c08317f32465")
 	)
 	(wire
 		(pts
-			(xy 148.59 29.21) (xy 148.59 20.32)
+			(xy 48.26 36.83) (xy 48.26 53.34)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "bdf1168e-2fdf-4645-aa58-4b680fbafe26")
+		(uuid "643e66b8-a6d8-48bf-9d19-f41835fb50a2")
 	)
 	(wire
 		(pts
-			(xy 45.72 20.32) (xy 59.69 20.32)
+			(xy 57.15 96.52) (xy 58.42 96.52)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "bf2d2679-f90c-41b5-98f4-d66eacac2827")
+		(uuid "65a93bb7-3716-41e3-8fea-797e1d867b77")
 	)
 	(wire
 		(pts
-			(xy 127 114.3) (xy 125.73 114.3)
+			(xy 125.73 96.52) (xy 124.46 96.52)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "bfff159d-dc9c-4fc7-8027-0da113e22c43")
+		(uuid "669973b3-7809-4cf7-95ca-1a4c8dcb609e")
 	)
 	(wire
 		(pts
-			(xy 90.17 30.48) (xy 90.17 33.02)
+			(xy 57.15 83.82) (xy 58.42 83.82)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c3d0d168-0833-4acd-83b9-682988dd5000")
+		(uuid "670fa248-140f-45d0-8afb-1a0c53b9d3c8")
 	)
 	(wire
 		(pts
-			(xy 58.42 86.36) (xy 59.69 86.36)
+			(xy 91.44 186.69) (xy 91.44 187.96)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c63f16b3-5c1b-4cce-b37f-95dad68a5b3c")
+		(uuid "67c67904-4c9b-4f87-8015-c39f5bd7a901")
 	)
 	(wire
 		(pts
-			(xy 127 137.16) (xy 125.73 137.16)
+			(xy 57.15 109.22) (xy 58.42 109.22)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c8201d98-e6da-4244-a8d9-3b7f62cdf829")
+		(uuid "68c7a9d9-6ae8-409f-ac5c-36a45b483f84")
 	)
 	(wire
 		(pts
-			(xy 58.42 93.98) (xy 59.69 93.98)
+			(xy 151.13 43.18) (xy 151.13 40.64)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d49da2ca-d35d-4bff-a965-81190ddf2040")
+		(uuid "6b78925d-85c2-4d7c-b3c1-ca9885e41581")
 	)
 	(wire
 		(pts
-			(xy 31.75 21.59) (xy 31.75 20.32)
+			(xy 88.9 33.02) (xy 88.9 36.83)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "de68e0c5-58f9-49b0-8447-5da533aeaf5a")
+		(uuid "6dfd53cc-cc74-4391-a3a4-e59e95e26bf0")
 	)
 	(wire
 		(pts
-			(xy 58.42 88.9) (xy 59.69 88.9)
+			(xy 57.15 104.14) (xy 58.42 104.14)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "e3db1b48-eb5c-4a98-9cb4-ebd0d142321f")
+		(uuid "723a24ed-edee-4300-a767-20e0c5c04cae")
 	)
 	(wire
 		(pts
-			(xy 69.85 20.32) (xy 72.39 20.32)
+			(xy 25.4 19.05) (xy 29.21 19.05)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "e6840cfd-5f22-46b1-aa0c-f7bfb6995635")
+		(uuid "7291d5ec-14d2-46a3-955a-31a5e9cccfc3")
 	)
 	(wire
 		(pts
-			(xy 58.42 116.84) (xy 59.69 116.84)
+			(xy 57.15 121.92) (xy 58.42 121.92)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "e7cf2423-87a8-463d-b981-ed220df3c8f5")
+		(uuid "73b3132b-8413-4317-9b50-4f22ec1b61f4")
 	)
 	(wire
 		(pts
-			(xy 115.57 21.59) (xy 115.57 20.32)
+			(xy 67.31 19.05) (xy 69.85 19.05)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "e7e67a7a-dff3-44e4-b2ee-967efd6d6515")
+		(uuid "765ad946-b98c-4a01-a380-94017ba21f13")
 	)
 	(wire
 		(pts
-			(xy 58.42 81.28) (xy 59.69 81.28)
+			(xy 114.3 26.67) (xy 114.3 25.4)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "ec5520e5-b852-4966-999f-1aba94023cea")
+		(uuid "89482503-36c8-4935-a700-bb6be62a93b1")
 	)
 	(wire
 		(pts
-			(xy 58.42 58.42) (xy 59.69 58.42)
+			(xy 57.15 154.94) (xy 58.42 154.94)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f8883f6c-5b5b-4182-86d2-ef403df6ad22")
+		(uuid "8ccfb554-3fc7-4d87-a5d0-b53ee34ccffd")
 	)
 	(wire
 		(pts
-			(xy 157.48 20.32) (xy 152.4 20.32)
+			(xy 57.15 76.2) (xy 58.42 76.2)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f9ab7170-9764-4666-ace4-8e7936386b0c")
+		(uuid "8d7d5df1-1a12-44d3-a451-7d761794310a")
 	)
 	(wire
 		(pts
-			(xy 72.39 20.32) (xy 88.9 20.32)
+			(xy 156.21 43.18) (xy 151.13 43.18)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f9e80f9b-0dda-4c69-ac7c-80eb28385434")
+		(uuid "8f514a4d-629c-4931-98c4-4bdcc8203a4f")
 	)
 	(wire
 		(pts
-			(xy 58.42 76.2) (xy 59.69 76.2)
+			(xy 43.18 19.05) (xy 43.18 20.32)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "faf195af-e363-4672-8ee2-91f354dc5f7c")
+		(uuid "922eb29b-71d6-464b-a422-759873de3950")
 	)
-	(label "ENABLE"
-		(at 49.53 48.26 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
+	(wire
+		(pts
+			(xy 57.15 127) (xy 58.42 127)
 		)
-		(uuid "6a1159dc-4588-455b-90cc-ce1585eba271")
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94c6e717-fe9e-426c-b8bd-7ae388ff2e00")
 	)
-	(label "ENABLE"
-		(at 88.9 30.48 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
+	(wire
+		(pts
+			(xy 57.15 93.98) (xy 58.42 93.98)
 		)
-		(uuid "f3048b94-885a-4e55-a594-d5f40a9165d8")
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94e34f4a-c327-44b0-940c-1f25341c194a")
+	)
+	(wire
+		(pts
+			(xy 57.15 119.38) (xy 58.42 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "98fdf54d-78ab-4845-9a2a-6adc184d3495")
+	)
+	(wire
+		(pts
+			(xy 125.73 73.66) (xy 124.46 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aa686c31-a9c3-4514-803f-46c19f9673a2")
+	)
+	(wire
+		(pts
+			(xy 69.85 19.05) (xy 88.9 19.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab3e5d05-459a-4e62-9ac0-b0a50459d59c")
+	)
+	(wire
+		(pts
+			(xy 57.15 73.66) (xy 58.42 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab6e326e-ea32-4a8e-a595-5fe79e64309c")
+	)
+	(wire
+		(pts
+			(xy 88.9 36.83) (xy 88.9 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b1267da2-107a-4eaa-9b1d-7a0dbde5c1f6")
+	)
+	(wire
+		(pts
+			(xy 95.25 25.4) (xy 105.41 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3bfb3d5-305f-4692-bc97-cbef3c4fbfef")
+	)
+	(wire
+		(pts
+			(xy 86.36 186.69) (xy 91.44 186.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b49cca5e-9ce1-4ad5-b50c-30efb3cef615")
+	)
+	(wire
+		(pts
+			(xy 151.13 25.4) (xy 156.21 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b6da7b2c-0bbd-444a-ae0c-073a4cb07f6c")
+	)
+	(wire
+		(pts
+			(xy 91.44 25.4) (xy 95.25 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b9bd24ae-c89a-4fda-a95f-37c5bce9012c")
+	)
+	(wire
+		(pts
+			(xy 125.73 157.48) (xy 124.46 157.48)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb688938-85aa-4c01-81ad-1d5c2b571820")
+	)
+	(wire
+		(pts
+			(xy 134.62 149.86) (xy 134.62 152.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "be9d2ee4-39d3-4ad1-aa78-ee9c0ed5d2d5")
+	)
+	(wire
+		(pts
+			(xy 57.15 99.06) (xy 58.42 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c24734bb-afb6-45f1-b0db-d8bd78b9bc17")
+	)
+	(wire
+		(pts
+			(xy 57.15 71.12) (xy 58.42 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c576726d-c239-46fe-840d-46b69cd09e3e")
+	)
+	(wire
+		(pts
+			(xy 125.73 119.38) (xy 124.46 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c661ded6-4adb-4661-830c-d1f167d79214")
+	)
+	(wire
+		(pts
+			(xy 57.15 124.46) (xy 58.42 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c681df32-b8fc-46c4-b9cb-03a1c5a256d0")
+	)
+	(wire
+		(pts
+			(xy 43.18 19.05) (xy 57.15 19.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb91f161-485a-4790-b08f-28463376c918")
+	)
+	(wire
+		(pts
+			(xy 57.15 157.48) (xy 58.42 157.48)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cca4bcc4-0d7f-47fe-802e-27995d8e236d")
+	)
+	(wire
+		(pts
+			(xy 48.26 36.83) (xy 88.9 36.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cf2fa750-2005-4e09-9896-352fa30a209a")
+	)
+	(wire
+		(pts
+			(xy 96.52 36.83) (xy 96.52 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cfda47aa-d014-4468-807f-b1a9ee54d683")
+	)
+	(wire
+		(pts
+			(xy 48.26 53.34) (xy 49.53 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2015404-e7b2-49a7-8499-37ecb919880f")
+	)
+	(wire
+		(pts
+			(xy 57.15 81.28) (xy 58.42 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d271a588-61d6-41f8-8d15-fbcebfb8460e")
+	)
+	(wire
+		(pts
+			(xy 134.62 152.4) (xy 142.24 152.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d3878484-7974-4123-82d0-e4a59970c9e8")
+	)
+	(wire
+		(pts
+			(xy 125.73 121.92) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d3f19c17-c720-4c6b-9dad-7c2b4119a14f")
+	)
+	(wire
+		(pts
+			(xy 57.15 19.05) (xy 57.15 20.32)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d740accb-1f4d-4f81-8f91-7b4199b1a1fd")
+	)
+	(wire
+		(pts
+			(xy 147.32 34.29) (xy 147.32 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc307265-78ea-4c00-b9c7-c2acef4d434e")
+	)
+	(wire
+		(pts
+			(xy 88.9 19.05) (xy 88.9 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ddfd7a44-1806-4b5c-8c4b-04e3b5e52929")
+	)
+	(wire
+		(pts
+			(xy 87.63 33.02) (xy 88.9 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de2fe609-a4f0-4786-a3ad-b0f60ca8e301")
+	)
+	(wire
+		(pts
+			(xy 57.15 19.05) (xy 59.69 19.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de865ef8-e1ff-4c19-97b8-8f5ef7f42809")
+	)
+	(wire
+		(pts
+			(xy 57.15 60.96) (xy 58.42 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e5544e43-1487-4235-ad5e-ca4d8ce00d95")
+	)
+	(wire
+		(pts
+			(xy 57.15 63.5) (xy 58.42 63.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e5e59071-dfe6-47dc-9f8c-0cba17777f30")
+	)
+	(wire
+		(pts
+			(xy 114.3 25.4) (xy 127 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e811b5d9-d08a-4bdb-9b0c-5c15464f75e7")
+	)
+	(wire
+		(pts
+			(xy 105.41 25.4) (xy 114.3 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "efddc2de-07ea-4fda-9bfc-d137d508f268")
+	)
+	(wire
+		(pts
+			(xy 36.83 114.3) (xy 39.37 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f3f5e0c3-e13f-4d6d-baf5-21d735730b79")
+	)
+	(wire
+		(pts
+			(xy 57.15 101.6) (xy 58.42 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f3fc150e-a90e-4aa3-bb6f-ff0ce5368e30")
+	)
+	(wire
+		(pts
+			(xy 69.85 19.05) (xy 69.85 20.32)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f79c26b3-4c92-4111-b861-fa2d577b441c")
+	)
+	(wire
+		(pts
+			(xy 127 26.67) (xy 127 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "faf55695-6f9b-4010-8041-9ed9c3e5dd73")
 	)
 	(global_label "VDD_1V8"
 		(shape input)
-		(at 97.79 31.75 0)
+		(at 156.21 25.4 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -3981,9 +4264,9 @@
 			)
 			(justify left)
 		)
-		(uuid "28602c9c-df69-4323-a180-3aabef5e3e20")
+		(uuid "2774a7b2-c24f-4830-a365-e0cdde1bfad4")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 108.879 31.75 0)
+			(at 167.299 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3995,7 +4278,7 @@
 	)
 	(global_label "VDD_1V8"
 		(shape input)
-		(at 157.48 20.32 0)
+		(at 96.52 36.83 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4003,9 +4286,31 @@
 			)
 			(justify left)
 		)
-		(uuid "41b5c20c-9bd4-4ffd-b4a9-db13db9ea924")
+		(uuid "7060d33c-f9bb-4949-8a20-45dd6665cdd0")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 168.569 20.32 0)
+			(at 107.609 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD_3V3"
+		(shape input)
+		(at 156.21 43.18 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bbe9db0e-1915-489b-9e5a-b518397fd6eb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 167.299 43.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4017,7 +4322,7 @@
 	)
 	(global_label "VDD_5V"
 		(shape input)
-		(at 27.94 20.32 180)
+		(at 25.4 19.05 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4025,9 +4330,9 @@
 			)
 			(justify right)
 		)
-		(uuid "78fbbb48-2136-4513-a5a3-41e31a24ca65")
+		(uuid "c39ce2d2-f692-41f4-a32f-9aa9253f3c1c")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 18.0605 20.32 0)
+			(at 15.5205 19.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4037,476 +4342,451 @@
 			)
 		)
 	)
-	(global_label "VDD_3V3"
-		(shape input)
-		(at 157.48 38.1 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "cdebde72-1c50-4661-9d2b-6419519e8bb1")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 168.569 38.1 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-				(hide yes)
-			)
-		)
-	)
-	(hierarchical_label "SPI_SCK2"
+	(hierarchical_label "PWM1"
 		(shape output)
-		(at 58.42 116.84 180)
+		(at 57.15 68.58 180)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify right)
 		)
-		(uuid "060bd548-3b0b-4538-9604-5768df16b278")
-	)
-	(hierarchical_label "AN1"
-		(shape input)
-		(at 58.42 91.44 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "0a97e6d1-0b88-41cf-a84a-1d62a0759245")
-	)
-	(hierarchical_label "AN2"
-		(shape input)
-		(at 58.42 109.22 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "124d4ec8-9a60-4f57-8785-03298823ca7e")
-	)
-	(hierarchical_label "UART_RX2"
-		(shape input)
-		(at 58.42 88.9 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "204d1b61-28db-435a-a47b-48fbcd57c3ce")
-	)
-	(hierarchical_label "SPI_MOSI1"
-		(shape output)
-		(at 58.42 66.04 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "22529834-6e71-44e3-8946-89fa35873ba7")
-	)
-	(hierarchical_label "SIM_CLK"
-		(shape output)
-		(at 58.42 147.32 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "24088025-2e99-40a5-96fb-e2a327ccccb3")
-	)
-	(hierarchical_label "INT1"
-		(shape input)
-		(at 58.42 58.42 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "250a866d-68cb-407d-b880-d97052dedf2d")
-	)
-	(hierarchical_label "SCL"
-		(shape output)
-		(at 127 137.16 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "2d38cd14-fdc5-4880-9dbe-3af71fd49142")
-	)
-	(hierarchical_label "SPI_MOSI2"
-		(shape output)
-		(at 58.42 111.76 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "3350b8e9-a7da-4b11-9ac9-8cbc81687488")
+		(uuid "00408e49-c4aa-46ac-89e5-7f3665de68ae")
 	)
 	(hierarchical_label "GNSS_ANTENNA"
 		(shape input)
-		(at 127 91.44 0)
+		(at 125.73 96.52 0)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify left)
 		)
-		(uuid "42584251-3f0d-4657-b249-5f26133bd71e")
-	)
-	(hierarchical_label "SIM_RST"
-		(shape output)
-		(at 58.42 152.4 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "4e14d332-1395-40da-b939-59ea4aa82e6e")
-	)
-	(hierarchical_label "I2C_SCL2"
-		(shape output)
-		(at 58.42 119.38 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "50715c17-914c-4d5f-8481-85a16829b50f")
-	)
-	(hierarchical_label "UART_RX1"
-		(shape input)
-		(at 58.42 83.82 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "512f54b1-e9d3-458e-a56c-6c074e3c7c3f")
-	)
-	(hierarchical_label "PWM1"
-		(shape output)
-		(at 58.42 63.5 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "5d28fcd6-5bf2-4805-93cf-cf2cacfd6fd1")
-	)
-	(hierarchical_label "SYSTEM_LED"
-		(shape output)
-		(at 58.42 101.6 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "5dc07629-1110-40a6-bc41-8f5ae97980a9")
-	)
-	(hierarchical_label "CS2"
-		(shape output)
-		(at 58.42 73.66 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "5de18f4e-74fe-4929-9d85-2d391c2e67e9")
-	)
-	(hierarchical_label "UART_TX"
-		(shape output)
-		(at 127 114.3 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "61c43772-ec2c-437b-ba97-24ff2c9ed528")
-	)
-	(hierarchical_label "I2C_SDA2"
-		(shape bidirectional)
-		(at 58.42 121.92 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "689a548b-1338-4da8-8c3e-849badc90d2e")
-	)
-	(hierarchical_label "INT2"
-		(shape input)
-		(at 58.42 93.98 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "6d302333-e207-4882-aaa6-aad1aed65dfc")
-	)
-	(hierarchical_label "LTE_ANTENNA"
-		(shape bidirectional)
-		(at 127 68.58 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "6fa4ca78-01c0-4bca-becb-abe7dd07c376")
-	)
-	(hierarchical_label "UART_TX2"
-		(shape output)
-		(at 58.42 86.36 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "7ce758bd-5012-4013-9757-e94424653387")
-	)
-	(hierarchical_label "RST1"
-		(shape output)
-		(at 58.42 60.96 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "80a60094-7e88-42d9-bf00-ecfb34166f11")
-	)
-	(hierarchical_label "SPI_MISO2"
-		(shape input)
-		(at 58.42 114.3 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "99e4858a-6522-4a5f-82ae-abb7baf3c64b")
-	)
-	(hierarchical_label "CS1"
-		(shape output)
-		(at 58.42 55.88 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "9b541b6d-e544-4a5d-aeb1-9e27ac6f9ed0")
-	)
-	(hierarchical_label "SWCLK"
-		(shape input)
-		(at 127 152.4 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "9df01b16-e5e8-4d01-8f6b-8b9536dcce6f")
-	)
-	(hierarchical_label "I2C_SCL1"
-		(shape output)
-		(at 58.42 76.2 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "9ebc9dc2-905a-433c-84b9-8df50cd52b75")
-	)
-	(hierarchical_label "SWDIO"
-		(shape bidirectional)
-		(at 127 154.94 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "aa99b99e-7d32-4da2-b3aa-a54ca75a83ae")
-	)
-	(hierarchical_label "SDA"
-		(shape bidirectional)
-		(at 127 139.7 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "aabd1b09-b5a7-44ee-926d-59cf948801a8")
-	)
-	(hierarchical_label "BUZZER"
-		(shape output)
-		(at 58.42 104.14 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "b3943ecf-30db-4395-a9df-52d84a97bab5")
-	)
-	(hierarchical_label "RST2"
-		(shape output)
-		(at 58.42 96.52 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "b70ee863-78d2-4328-9d08-4de106b367fb")
-	)
-	(hierarchical_label "SPI_MISO1"
-		(shape input)
-		(at 58.42 68.58 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "b88d7bdf-2830-4a76-afe7-ad9c447e5bc0")
-	)
-	(hierarchical_label "I2C_SDA1"
-		(shape bidirectional)
-		(at 58.42 78.74 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "c896924e-c3dc-460e-8c0a-5a30449b5efc")
-	)
-	(hierarchical_label "nRESET"
-		(shape input)
-		(at 127 147.32 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "e2d7b9e1-d9cb-449d-9e14-29fe09616cc1")
+		(uuid "01543da6-32a5-43db-ad22-1fc5b31d17fd")
 	)
 	(hierarchical_label "PWN2"
 		(shape output)
-		(at 58.42 99.06 180)
+		(at 57.15 104.14 180)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify right)
 		)
-		(uuid "e732d792-f9ff-4222-8356-53361519d764")
+		(uuid "0be7647b-71d4-4f3c-a6e1-8ae925b909c4")
 	)
-	(hierarchical_label "SPI_SCK1"
+	(hierarchical_label "BUZZER"
 		(shape output)
-		(at 58.42 71.12 180)
+		(at 57.15 109.22 180)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify right)
 		)
-		(uuid "e8b0e6ce-0e4c-4efd-ae5f-bef20c3b75b1")
+		(uuid "18575d60-ccec-4ee5-b3d1-fde7c9dfb27c")
+	)
+	(hierarchical_label "INT2"
+		(shape input)
+		(at 57.15 99.06 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1e94b76d-c9b3-4d61-8a4b-fe976c08c33c")
 	)
 	(hierarchical_label "SIM_IO"
 		(shape bidirectional)
-		(at 58.42 149.86 180)
+		(at 57.15 154.94 180)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify right)
 		)
-		(uuid "f33c836f-2726-4da9-82b6-aeb9c825477f")
+		(uuid "30773c44-a03f-4ff3-bab7-938a3aeed958")
 	)
-	(hierarchical_label "UART_TX1"
-		(shape output)
-		(at 58.42 81.28 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "fe5d1a2a-3334-4df3-8e7c-b905a4ffe49d")
-	)
-	(hierarchical_label "UART_RX"
-		(shape input)
-		(at 127 111.76 0)
+	(hierarchical_label "LTE_ANTENNA"
+		(shape bidirectional)
+		(at 125.73 73.66 0)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify left)
 		)
-		(uuid "ff8cefb4-3c49-4f4c-8e76-209615d4e2bd")
+		(uuid "33e7f96d-7bd5-453c-90a3-acc4450fd8ab")
+	)
+	(hierarchical_label "SDA"
+		(shape bidirectional)
+		(at 57.15 124.46 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3a4f09f8-66c4-45fb-8d80-b1c62af81160")
+	)
+	(hierarchical_label "SPI_MISO2"
+		(shape input)
+		(at 57.15 119.38 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "46f34cd7-2fb7-4ce4-ae14-9fb59a62c724")
+	)
+	(hierarchical_label "SPI_MISO1"
+		(shape input)
+		(at 57.15 73.66 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4843ee24-b4e2-4765-be07-c47d953942aa")
+	)
+	(hierarchical_label "UART_TX"
+		(shape output)
+		(at 36.83 116.84 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4983aed4-4d02-4fc6-9c24-24e786793571")
+	)
+	(hierarchical_label "I2C_SDA2"
+		(shape bidirectional)
+		(at 125.73 119.38 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "49876cc4-0112-4813-b92f-82ba2a9db3f3")
+	)
+	(hierarchical_label "I2C_SCL2"
+		(shape output)
+		(at 125.73 121.92 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4b3bb8c0-adc2-4ab9-afdb-9eebcf93d39a")
+	)
+	(hierarchical_label "CS1"
+		(shape output)
+		(at 57.15 60.96 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4d78862b-e92c-44b9-be56-24d288eb88f4")
+	)
+	(hierarchical_label "SPI_SCK2"
+		(shape output)
+		(at 57.15 121.92 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "53484025-0e80-4b04-af07-f0721ac79a02")
+	)
+	(hierarchical_label "UART_RX"
+		(shape input)
+		(at 36.83 114.3 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5c7e2e91-e4b2-42a9-b784-cabecf9829e6")
+	)
+	(hierarchical_label "SWCLK"
+		(shape input)
+		(at 125.73 157.48 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "61ebe08f-a31a-44b7-ba11-df8a1875fb50")
+	)
+	(hierarchical_label "SPI_SCK1"
+		(shape output)
+		(at 57.15 76.2 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "77bb6d5c-46ee-4543-815d-bc2b1e28a04b")
+	)
+	(hierarchical_label "nRESET"
+		(shape input)
+		(at 157.48 152.4 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "79618eac-2e61-454a-b51d-64fa5720bb05")
+	)
+	(hierarchical_label "I2C_SDA1"
+		(shape bidirectional)
+		(at 57.15 83.82 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "83e42447-87e4-4e8e-994e-9d768bf28c0c")
+	)
+	(hierarchical_label "SIM_CLK"
+		(shape output)
+		(at 57.15 152.4 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "88cb5128-eca0-4ddd-9a2c-bf7788cc3bd4")
+	)
+	(hierarchical_label "I2C_SCL1"
+		(shape output)
+		(at 57.15 81.28 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8b5ce876-1a79-489d-ad29-4178f9217caf")
+	)
+	(hierarchical_label "UART_TX2"
+		(shape output)
+		(at 57.15 91.44 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8c846387-45c3-4e85-9a03-301e388f3619")
+	)
+	(hierarchical_label "SYSTEM_LED"
+		(shape output)
+		(at 57.15 106.68 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8ede0a89-fbbc-4d3c-bc47-5de5e9f0ce82")
+	)
+	(hierarchical_label "INT1"
+		(shape input)
+		(at 57.15 63.5 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "91455a59-8577-44b9-9fa4-837e1b192b40")
+	)
+	(hierarchical_label "CS2"
+		(shape output)
+		(at 57.15 78.74 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9697fdd1-4804-4517-95df-637e23707344")
+	)
+	(hierarchical_label "AN1"
+		(shape input)
+		(at 57.15 96.52 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9c528f97-db13-4510-bc26-02accbd20851")
+	)
+	(hierarchical_label "SPI_MOSI2"
+		(shape output)
+		(at 125.73 116.84 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a0332c55-78fd-4524-85f8-b03d5ea837c2")
+	)
+	(hierarchical_label "SIM_RST"
+		(shape output)
+		(at 57.15 157.48 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a22706eb-8279-49a8-950e-446bf563a0a3")
+	)
+	(hierarchical_label "UART_RX2"
+		(shape input)
+		(at 57.15 93.98 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a63afc09-25f1-4271-81f4-881bd17d978a")
+	)
+	(hierarchical_label "UART_TX1"
+		(shape output)
+		(at 57.15 86.36 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a6ce4d87-5395-42cf-a924-fac511645915")
+	)
+	(hierarchical_label "SWDIO"
+		(shape bidirectional)
+		(at 125.73 160.02 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bc7b1c28-6213-4f9b-955e-d8f78e489a45")
+	)
+	(hierarchical_label "RST2"
+		(shape output)
+		(at 57.15 101.6 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c8a518bf-4ece-46c0-b762-36680e3976a9")
+	)
+	(hierarchical_label "SPI_MOSI1"
+		(shape output)
+		(at 57.15 71.12 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "cc48f2d7-0ece-4707-b3a5-b8828de835e3")
+	)
+	(hierarchical_label "RST1"
+		(shape output)
+		(at 57.15 66.04 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "cf5db7ab-c987-438e-8804-6babd9817309")
+	)
+	(hierarchical_label "SCL"
+		(shape output)
+		(at 57.15 127 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d141a323-b839-4302-bf22-b3544fc32a6f")
+	)
+	(hierarchical_label "AN2"
+		(shape input)
+		(at 57.15 111.76 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e0e5a326-d3cc-4297-a85c-7bda6de31894")
+	)
+	(hierarchical_label "UART_RX1"
+		(shape input)
+		(at 57.15 88.9 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f046f209-5593-4639-aba8-d88949decc85")
 	)
 	(symbol
-		(lib_id "seven_lib:C")
-		(at 59.69 25.4 0)
+		(lib_id "seven_lib:TestPoint")
+		(at 105.41 25.4 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "220c8755-398d-4cf2-ba49-f1bb0e0466f9")
-		(property "Reference" "C7"
-			(at 63.5 24.1299 0)
+		(uuid "15babf7b-c0b6-4c9b-b46c-28decd8cd85d")
+		(property "Reference" "TP3"
+			(at 101.473 27.305 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
 			)
 		)
-		(property "Value" "10uF"
-			(at 63.5 26.6699 0)
+		(property "Value" "VDD_GPIO"
+			(at 101.473 29.845 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
 			)
 		)
-		(property "Footprint" "seven-lib:C_0402_1005Metric"
-			(at 60.6552 29.21 0)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 100.33 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4515,7 +4795,74 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 59.69 25.4 0)
+			(at 100.33 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 105.41 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ed502b2f-20b2-4725-9914-4374fec88426")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
+					(reference "TP3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:C")
+		(at 57.15 24.13 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "220c8755-398d-4cf2-ba49-f1bb0e0466f9")
+		(property "Reference" "C7"
+			(at 60.96 22.8599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "10uF"
+			(at 60.96 25.3999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "seven-lib:C_0402_1005Metric"
+			(at 58.1152 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 57.15 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4524,7 +4871,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 59.69 25.4 0)
+			(at 57.15 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4549,7 +4896,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:C")
-		(at 130.81 48.26 270)
+		(at 129.54 53.34 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4558,7 +4905,7 @@
 		(fields_autoplaced yes)
 		(uuid "363571bb-b62d-46c1-adae-ee89faacf5ea")
 		(property "Reference" "C2"
-			(at 130.81 40.64 90)
+			(at 129.54 45.72 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4566,7 +4913,7 @@
 			)
 		)
 		(property "Value" "4.7uF"
-			(at 130.81 43.18 90)
+			(at 129.54 48.26 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4574,7 +4921,7 @@
 			)
 		)
 		(property "Footprint" "seven-lib:C_0402_1005Metric"
-			(at 127 49.2252 0)
+			(at 125.73 54.3052 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4583,7 +4930,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 130.81 48.26 0)
+			(at 129.54 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4592,7 +4939,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 130.81 48.26 0)
+			(at 129.54 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4607,7 +4954,7 @@
 			(uuid "7200273a-69f3-4754-8353-8c32fcffb682")
 		)
 		(instances
-			(project ""
+			(project "seven"
 				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
 					(reference "C2")
 					(unit 1)
@@ -4617,7 +4964,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:GND")
-		(at 128.27 29.21 0)
+		(at 127 34.29 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4625,7 +4972,7 @@
 		(dnp no)
 		(uuid "36ac1423-7c40-4005-98de-775181412c78")
 		(property "Reference" "#PWR010"
-			(at 128.27 35.56 0)
+			(at 127 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4634,7 +4981,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 128.27 34.29 90)
+			(at 127 39.37 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4642,7 +4989,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 128.27 29.21 0)
+			(at 127 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4651,7 +4998,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 128.27 29.21 0)
+			(at 127 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4660,7 +5007,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 128.27 29.21 0)
+			(at 127 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4682,7 +5029,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:C")
-		(at 72.39 25.4 0)
+		(at 69.85 24.13 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4691,7 +5038,7 @@
 		(fields_autoplaced yes)
 		(uuid "5643440c-8f06-46f9-8b3a-30907ec256f2")
 		(property "Reference" "C8"
-			(at 76.2 24.1299 0)
+			(at 73.66 22.8599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4700,7 +5047,7 @@
 			)
 		)
 		(property "Value" "1.0uF"
-			(at 76.2 26.6699 0)
+			(at 73.66 25.3999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4709,7 +5056,7 @@
 			)
 		)
 		(property "Footprint" "seven-lib:C_0402_1005Metric"
-			(at 73.3552 29.21 0)
+			(at 70.8152 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4718,7 +5065,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 72.39 25.4 0)
+			(at 69.85 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4727,7 +5074,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 72.39 25.4 0)
+			(at 69.85 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4752,7 +5099,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:PWR_FLAG")
-		(at 99.06 20.32 0)
+		(at 95.25 25.4 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4761,7 +5108,7 @@
 		(fields_autoplaced yes)
 		(uuid "5af4332f-ebf1-43e1-85e9-dd9b8cb24ce7")
 		(property "Reference" "#FLG03"
-			(at 99.06 18.415 0)
+			(at 95.25 23.495 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4770,7 +5117,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 99.06 15.24 0)
+			(at 95.25 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4778,7 +5125,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 99.06 20.32 0)
+			(at 95.25 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4787,7 +5134,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 99.06 20.32 0)
+			(at 95.25 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4796,7 +5143,7 @@
 			)
 		)
 		(property "Description" "Special symbol for telling ERC where power comes from"
-			(at 99.06 20.32 0)
+			(at 95.25 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4818,7 +5165,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:nRF9151-LAXX")
-		(at 92.71 106.68 0)
+		(at 91.44 111.76 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4827,7 +5174,7 @@
 		(fields_autoplaced yes)
 		(uuid "682e17b8-ef0b-4245-9dbf-08f0a99df590")
 		(property "Reference" "U1"
-			(at 92.71 106.68 0)
+			(at 91.44 111.76 0)
 			(do_not_autoplace yes)
 			(effects
 				(font
@@ -4836,7 +5183,7 @@
 			)
 		)
 		(property "Value" "nRF9151-LAXX"
-			(at 92.71 109.22 0)
+			(at 91.44 114.3 0)
 			(do_not_autoplace yes)
 			(effects
 				(font
@@ -4845,7 +5192,7 @@
 			)
 		)
 		(property "Footprint" "seven-lib:LGA_9151_12.1x11.1mm"
-			(at 92.71 193.04 0)
+			(at 91.44 198.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4854,7 +5201,7 @@
 			)
 		)
 		(property "Datasheet" "https://docs.nordicsemi.com/bundle/ps_nrf9151/page/nRF9151_html5_keyfeatures.html"
-			(at 92.71 195.58 0)
+			(at 91.44 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4863,7 +5210,7 @@
 			)
 		)
 		(property "Description" "LTE-M/NB-IoT/DECT-NR+ SiP, ARM Cortex-M33, GNSS, LGA-100"
-			(at 92.71 198.12 0)
+			(at 91.44 203.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5221,7 +5568,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:GND")
-		(at 92.71 182.88 0)
+		(at 91.44 187.96 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5229,7 +5576,7 @@
 		(dnp no)
 		(uuid "6c6368ea-d496-4409-8317-75c3eb3d7689")
 		(property "Reference" "#PWR027"
-			(at 92.71 189.23 0)
+			(at 91.44 194.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5238,7 +5585,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 92.71 187.96 90)
+			(at 91.44 193.04 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5246,7 +5593,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 92.71 182.88 0)
+			(at 91.44 187.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5255,7 +5602,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 92.71 182.88 0)
+			(at 91.44 187.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5264,7 +5611,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 92.71 182.88 0)
+			(at 91.44 187.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5285,8 +5632,73 @@
 		)
 	)
 	(symbol
+		(lib_id "seven_lib:GND")
+		(at 142.24 161.29 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6eb21c43-d0aa-4faf-9fc1-882999890c19")
+		(property "Reference" "#PWR041"
+			(at 142.24 167.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 142.24 166.37 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 142.24 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 142.24 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 142.24 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "295423be-dac7-459a-a6d9-2bf249a41970")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
+					(reference "#PWR041")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "seven_lib:C")
-		(at 115.57 25.4 0)
+		(at 114.3 30.48 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5295,7 +5707,7 @@
 		(fields_autoplaced yes)
 		(uuid "71924d93-a0f5-4a9f-a88a-24b69fddfe07")
 		(property "Reference" "C13"
-			(at 119.38 24.1299 0)
+			(at 118.11 29.2099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5304,7 +5716,7 @@
 			)
 		)
 		(property "Value" "4.7uF"
-			(at 119.38 26.6699 0)
+			(at 118.11 31.7499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5313,7 +5725,7 @@
 			)
 		)
 		(property "Footprint" "seven-lib:C_0402_1005Metric"
-			(at 116.5352 29.21 0)
+			(at 115.2652 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5322,7 +5734,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 115.57 25.4 0)
+			(at 114.3 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5331,7 +5743,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 115.57 25.4 0)
+			(at 114.3 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5356,7 +5768,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:Jumper_3_Open")
-		(at 152.4 29.21 270)
+		(at 151.13 34.29 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom no)
@@ -5365,7 +5777,7 @@
 		(fields_autoplaced yes)
 		(uuid "72fffd6f-d309-40ad-8054-cf5a576956c6")
 		(property "Reference" "JP1"
-			(at 154.94 27.9399 90)
+			(at 153.67 33.0199 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5374,7 +5786,7 @@
 			)
 		)
 		(property "Value" "Jumper_3_Open"
-			(at 154.94 30.4799 90)
+			(at 153.67 35.5599 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5383,7 +5795,7 @@
 			)
 		)
 		(property "Footprint" "seven-lib:PinHeader_1x03_P2.54mm_Vertical_SMD_Pin1Left"
-			(at 152.4 29.21 0)
+			(at 151.13 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5392,7 +5804,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 152.4 29.21 0)
+			(at 151.13 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5401,7 +5813,7 @@
 			)
 		)
 		(property "Description" "Jumper, 3-pole, both open"
-			(at 152.4 29.21 0)
+			(at 151.13 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5419,7 +5831,7 @@
 			(uuid "97f01965-85bc-4137-94fa-49c1a3a97dc7")
 		)
 		(instances
-			(project ""
+			(project "seven"
 				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
 					(reference "JP1")
 					(unit 1)
@@ -5429,7 +5841,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:FerriteBead")
-		(at 66.04 20.32 90)
+		(at 63.5 19.05 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5437,7 +5849,7 @@
 		(dnp no)
 		(uuid "8e70a1d7-f33d-4690-8c90-a9cd48a0761a")
 		(property "Reference" "FB1"
-			(at 66.04 14.986 90)
+			(at 63.5 13.716 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5445,7 +5857,7 @@
 			)
 		)
 		(property "Value" "22Ω @ 100MHz"
-			(at 66.294 17.272 90)
+			(at 63.754 16.002 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5453,7 +5865,7 @@
 			)
 		)
 		(property "Footprint" "seven-lib:L_0603_1608Metric"
-			(at 66.04 22.098 90)
+			(at 63.5 20.828 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5462,7 +5874,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 66.04 20.32 0)
+			(at 63.5 19.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5471,7 +5883,7 @@
 			)
 		)
 		(property "Description" "Ferrite bead"
-			(at 66.04 20.32 0)
+			(at 63.5 19.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5486,7 +5898,7 @@
 			(uuid "a9a1d7b8-e63d-406f-ba20-198a3723d649")
 		)
 		(instances
-			(project ""
+			(project "seven"
 				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
 					(reference "FB1")
 					(unit 1)
@@ -5495,35 +5907,32 @@
 		)
 	)
 	(symbol
-		(lib_id "seven_lib:C")
-		(at 31.75 25.4 0)
+		(lib_id "seven_lib:TestPoint")
+		(at 87.63 33.02 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "9f065961-87ec-4cc1-a79f-de7f8a2cc766")
-		(property "Reference" "C5"
-			(at 35.56 24.1299 0)
+		(uuid "92bc2279-7056-400d-8181-e76c5efbc656")
+		(property "Reference" "TP2"
+			(at 84.328 27.94 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
 			)
 		)
-		(property "Value" "1.0uF"
-			(at 35.56 26.6699 0)
+		(property "Value" "VDD_5V"
+			(at 84.328 30.48 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
 			)
 		)
-		(property "Footprint" "seven-lib:C_0402_1005Metric"
-			(at 32.7152 29.21 0)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 87.63 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5532,7 +5941,139 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 31.75 25.4 0)
+			(at 87.63 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 87.63 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5cac75b6-db7d-4bd3-a4af-4f321d2b9860")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
+					(reference "TP2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 86.36 186.69 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "999ce614-3e08-4c4e-8dc9-bbca9686bb80")
+		(property "Reference" "TP1"
+			(at 83.058 181.61 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 83.058 184.15 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 86.36 181.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 86.36 181.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 86.36 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cf582798-d049-444f-b16f-156e3881b9b6")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
+					(reference "TP1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:C")
+		(at 29.21 24.13 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9f065961-87ec-4cc1-a79f-de7f8a2cc766")
+		(property "Reference" "C5"
+			(at 33.02 22.8599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "1.0uF"
+			(at 33.02 25.3999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "seven-lib:C_0402_1005Metric"
+			(at 30.1752 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 29.21 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5541,7 +6082,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 31.75 25.4 0)
+			(at 29.21 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5566,7 +6107,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:C")
-		(at 45.72 25.4 0)
+		(at 43.18 24.13 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5575,7 +6116,7 @@
 		(fields_autoplaced yes)
 		(uuid "b1a70c1a-6da2-4e77-9e02-25af82171796")
 		(property "Reference" "C6"
-			(at 49.53 24.1299 0)
+			(at 46.99 22.8599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5584,7 +6125,7 @@
 			)
 		)
 		(property "Value" "1.0uF"
-			(at 49.53 26.6699 0)
+			(at 46.99 25.3999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5593,7 +6134,7 @@
 			)
 		)
 		(property "Footprint" "seven-lib:C_0402_1005Metric"
-			(at 46.6852 29.21 0)
+			(at 44.1452 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5602,7 +6143,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 45.72 25.4 0)
+			(at 43.18 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5611,7 +6152,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 45.72 25.4 0)
+			(at 43.18 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5636,7 +6177,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:PWR_FLAG")
-		(at 88.9 20.32 0)
+		(at 88.9 19.05 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5645,7 +6186,7 @@
 		(fields_autoplaced yes)
 		(uuid "b1ad7d9f-96f2-4600-8d52-9addc8f83eee")
 		(property "Reference" "#FLG05"
-			(at 88.9 18.415 0)
+			(at 88.9 17.145 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5654,7 +6195,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 88.9 15.24 0)
+			(at 88.9 13.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5662,7 +6203,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 88.9 20.32 0)
+			(at 88.9 19.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5671,7 +6212,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 88.9 20.32 0)
+			(at 88.9 19.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5680,7 +6221,7 @@
 			)
 		)
 		(property "Description" "Special symbol for telling ERC where power comes from"
-			(at 88.9 20.32 0)
+			(at 88.9 19.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5702,7 +6243,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:GND")
-		(at 59.69 29.21 0)
+		(at 57.15 27.94 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5710,7 +6251,7 @@
 		(dnp no)
 		(uuid "b62ed27c-6d2d-41b0-b08f-2d51c4e0e134")
 		(property "Reference" "#PWR015"
-			(at 59.69 35.56 0)
+			(at 57.15 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5719,7 +6260,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 59.69 34.29 90)
+			(at 57.15 33.02 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5727,7 +6268,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 59.69 29.21 0)
+			(at 57.15 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5736,7 +6277,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 59.69 29.21 0)
+			(at 57.15 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5745,7 +6286,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 59.69 29.21 0)
+			(at 57.15 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5767,7 +6308,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:GND")
-		(at 72.39 29.21 0)
+		(at 69.85 27.94 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5775,7 +6316,7 @@
 		(dnp no)
 		(uuid "b865f250-e0df-40d2-9fe8-bd9ff1c35be2")
 		(property "Reference" "#PWR016"
-			(at 72.39 35.56 0)
+			(at 69.85 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5784,7 +6325,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 72.39 34.29 90)
+			(at 69.85 33.02 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5792,7 +6333,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 72.39 29.21 0)
+			(at 69.85 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5801,7 +6342,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 72.39 29.21 0)
+			(at 69.85 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5810,7 +6351,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 72.39 29.21 0)
+			(at 69.85 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5831,33 +6372,32 @@
 		)
 	)
 	(symbol
-		(lib_id "seven_lib:R")
-		(at 54.61 48.26 90)
+		(lib_id "seven_lib:TestPoint")
+		(at 39.37 116.84 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "c50c0eac-4885-4be6-aa0c-04431e088cd5")
-		(property "Reference" "R2"
-			(at 54.61 41.91 90)
+		(uuid "c2054538-8f76-4b62-a4db-5c915ff36e07")
+		(property "Reference" "TP14"
+			(at 35.433 118.745 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 			)
 		)
-		(property "Value" "10k"
-			(at 54.61 44.45 90)
+		(property "Value" "UART_TX"
+			(at 35.433 121.285 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 			)
 		)
-		(property "Footprint" "seven-lib:R_0402_1005Metric"
-			(at 54.61 50.038 90)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 34.29 116.84 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5866,7 +6406,136 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 54.61 48.26 0)
+			(at 34.29 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 39.37 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "71efd9f3-5144-4852-9bb4-b812ffcc9805")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
+					(reference "TP14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 134.62 149.86 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c33540c6-defa-4aa9-8406-a7ac884486da")
+		(property "Reference" "TP4"
+			(at 138.303 145.415 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "RESET"
+			(at 138.303 147.955 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 139.7 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 134.62 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d1b909fd-f859-4875-9f3e-cc88feaaf78c")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
+					(reference "TP4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:R")
+		(at 53.34 53.34 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c50c0eac-4885-4be6-aa0c-04431e088cd5")
+		(property "Reference" "R2"
+			(at 53.34 46.99 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 53.34 49.53 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:R_0402_1005Metric"
+			(at 53.34 55.118 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 53.34 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5875,7 +6544,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 54.61 48.26 0)
+			(at 53.34 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5890,7 +6559,7 @@
 			(uuid "dfe09f01-40fa-4d4d-a60f-9d6f3d361efa")
 		)
 		(instances
-			(project ""
+			(project "seven"
 				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
 					(reference "R2")
 					(unit 1)
@@ -5900,16 +6569,16 @@
 	)
 	(symbol
 		(lib_id "seven_lib:C")
-		(at 128.27 25.4 0)
+		(at 142.24 156.21 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "ccbd37bc-4896-43eb-8bbf-8f66241bc0ec")
-		(property "Reference" "C14"
-			(at 132.08 24.1299 0)
+		(uuid "cc1a324f-6e71-4143-8117-7a95d6b0dde9")
+		(property "Reference" "C21"
+			(at 146.05 154.9399 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5918,7 +6587,7 @@
 			)
 		)
 		(property "Value" "100nF"
-			(at 132.08 26.6699 0)
+			(at 146.05 157.4799 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5927,7 +6596,7 @@
 			)
 		)
 		(property "Footprint" "seven-lib:C_0402_1005Metric"
-			(at 129.2352 29.21 0)
+			(at 143.2052 160.02 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5936,7 +6605,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 128.27 25.4 0)
+			(at 142.24 156.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5945,7 +6614,77 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 128.27 25.4 0)
+			(at 142.24 156.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "76ba1ff0-6088-4f05-8058-87b7423e3b14")
+		)
+		(pin "2"
+			(uuid "c595b72a-156e-4f56-9a3c-fdb4b8c198ca")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
+					(reference "C21")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:C")
+		(at 127 30.48 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ccbd37bc-4896-43eb-8bbf-8f66241bc0ec")
+		(property "Reference" "C14"
+			(at 130.81 29.2099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 130.81 31.7499 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "seven-lib:C_0402_1005Metric"
+			(at 127.9652 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 127 30.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 127 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5970,7 +6709,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:GND")
-		(at 45.72 29.21 0)
+		(at 43.18 27.94 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5978,7 +6717,7 @@
 		(dnp no)
 		(uuid "d042ddb8-bcc7-4dc5-b751-639446921d1a")
 		(property "Reference" "#PWR014"
-			(at 45.72 35.56 0)
+			(at 43.18 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5987,7 +6726,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 45.72 34.29 90)
+			(at 43.18 33.02 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5995,7 +6734,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 45.72 29.21 0)
+			(at 43.18 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6004,7 +6743,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 45.72 29.21 0)
+			(at 43.18 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6013,7 +6752,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 45.72 29.21 0)
+			(at 43.18 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6034,8 +6773,72 @@
 		)
 	)
 	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 39.37 114.3 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "df652d10-0a82-4aff-9f23-9701c5e98f8d")
+		(property "Reference" "TP15"
+			(at 43.053 109.855 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "UART_RX"
+			(at 43.053 112.395 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 44.45 114.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 44.45 114.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 39.37 114.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8ad87a43-ee17-4b17-8122-94c70683ee6f")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
+					(reference "TP15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "seven_lib:GND")
-		(at 115.57 29.21 0)
+		(at 114.3 34.29 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6043,7 +6846,7 @@
 		(dnp no)
 		(uuid "e030bc40-ab44-4db9-8ce2-9a1e4a23f6ab")
 		(property "Reference" "#PWR017"
-			(at 115.57 35.56 0)
+			(at 114.3 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6052,7 +6855,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 115.57 34.29 90)
+			(at 114.3 39.37 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6060,7 +6863,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 115.57 29.21 0)
+			(at 114.3 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6069,7 +6872,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 115.57 29.21 0)
+			(at 114.3 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6078,7 +6881,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 115.57 29.21 0)
+			(at 114.3 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6100,7 +6903,7 @@
 	)
 	(symbol
 		(lib_id "seven_lib:GND")
-		(at 31.75 29.21 0)
+		(at 29.21 27.94 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6108,7 +6911,7 @@
 		(dnp no)
 		(uuid "e4516246-6fb2-4b5a-9bd4-b3bf8674d645")
 		(property "Reference" "#PWR013"
-			(at 31.75 35.56 0)
+			(at 29.21 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6117,7 +6920,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 31.75 34.29 90)
+			(at 29.21 33.02 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6125,7 +6928,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 31.75 29.21 0)
+			(at 29.21 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6134,7 +6937,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 31.75 29.21 0)
+			(at 29.21 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6143,7 +6946,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 31.75 29.21 0)
+			(at 29.21 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6164,8 +6967,76 @@
 		)
 	)
 	(symbol
+		(lib_id "seven_lib:R")
+		(at 152.4 152.4 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f8a2a467-0952-4e2e-bcea-260996aa2d0e")
+		(property "Reference" "R15"
+			(at 152.4 146.05 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 152.4 148.59 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:R_0402_1005Metric"
+			(at 152.4 154.178 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 152.4 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 152.4 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "514f5ef7-795c-4e1b-9261-3b0ffeff7328")
+		)
+		(pin "2"
+			(uuid "5a2110b2-773f-4491-b608-797cef59f139")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/cf07285a-6c1b-4971-a8bc-a281923e473a"
+					(reference "R15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "seven_lib:GND")
-		(at 137.16 48.26 90)
+		(at 135.89 53.34 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6173,7 +7044,7 @@
 		(dnp no)
 		(uuid "fcc608c8-8c14-478e-9a4f-5ccee1c84fc6")
 		(property "Reference" "#PWR012"
-			(at 143.51 48.26 0)
+			(at 142.24 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6182,7 +7053,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 142.24 48.26 90)
+			(at 140.97 53.34 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6190,7 +7061,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 137.16 48.26 0)
+			(at 135.89 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6199,7 +7070,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 137.16 48.26 0)
+			(at 135.89 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6208,7 +7079,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 137.16 48.26 0)
+			(at 135.89 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/kicad/mikroBUS_1.kicad_sch
+++ b/kicad/mikroBUS_1.kicad_sch
@@ -501,7 +501,7 @@
 		)
 		(uuid "78dfc42b-a088-4629-b7a4-49e0e1087a14")
 	)
-	(text_box "NOTE: BE caution of all Clicker Board sizes when placing footprint"
+	(text_box "Note: Be cautious of all Clicker Board sizes when placing the footprint."
 		(exclude_from_sim no)
 		(at 116.84 46.99 0)
 		(size 25.4 12.7)
@@ -524,10 +524,10 @@
 		)
 		(uuid "be2cc12a-7a91-402c-b9f2-6936d6f9ab27")
 	)
-	(text_box "NOTE: Click boards come in S,M and L sizes. L size should be incounted for in PCB being 57mm"
+	(text_box "Note: Click boards come in S, M, and L sizes. The L size should be accounted for in the PCB design, with a length of 57 mm."
 		(exclude_from_sim no)
 		(at 115.57 71.12 0)
-		(size 25.4 12.7)
+		(size 25.4 15.24)
 		(margins 0.9525 0.9525 0.9525 0.9525)
 		(stroke
 			(width 0)

--- a/kicad/mikroBUS_2.kicad_sch
+++ b/kicad/mikroBUS_2.kicad_sch
@@ -459,6 +459,29 @@
 			(embedded_fonts no)
 		)
 	)
+	(text_box "Note: Be cautious of all Clicker Board sizes when placing the footprint."
+		(exclude_from_sim no)
+		(at 124.46 53.34 0)
+		(size 25.4 12.7)
+		(margins 0.9525 0.9525 0.9525 0.9525)
+		(stroke
+			(width 0)
+			(type solid)
+			(color 255 0 0 1)
+		)
+		(fill
+			(type color)
+			(color 255 67 78 1)
+		)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(color 0 0 0 1)
+			)
+			(justify left top)
+		)
+		(uuid "03561d4e-31d3-447c-b685-422da3275c1c")
+	)
 	(text_box "mikroBUS Socket 2"
 		(exclude_from_sim no)
 		(at 176.53 12.7 0)
@@ -503,10 +526,10 @@
 		)
 		(uuid "66d84b42-61da-4efa-b3eb-9c1dd67dbe04")
 	)
-	(text_box "NOTE: Click boards come in S,M and L sizes. L size should be incounted for in PCB being 57mm"
+	(text_box "Note: Click boards come in S, M, and L sizes. The L size should be accounted for in the PCB design, with a length of 57 mm."
 		(exclude_from_sim no)
-		(at 120.65 64.77 0)
-		(size 25.4 12.7)
+		(at 123.19 77.47 0)
+		(size 25.4 15.24)
 		(margins 0.9525 0.9525 0.9525 0.9525)
 		(stroke
 			(width 0)
@@ -524,7 +547,7 @@
 			)
 			(justify left top)
 		)
-		(uuid "8c1c4d09-a29e-4cc7-866c-0283077eb06a")
+		(uuid "82de2f74-d62a-46e1-afda-c97089e3833e")
 	)
 	(text_box "This circuit implements a MikroBUS expansion interface, a standardized connectivity interface for embedded add-on boards. It exposes power rails and several MCU communication signals to allow connection of MikroBUS-compatible peripheral modules."
 		(exclude_from_sim no)
@@ -545,29 +568,6 @@
 			(justify left top)
 		)
 		(uuid "8e7eefbe-3202-4892-be9b-26d072c3e96a")
-	)
-	(text_box "NOTE: BE caution of all Clicker Board sizes when placing footprint"
-		(exclude_from_sim no)
-		(at 120.65 48.26 0)
-		(size 25.4 12.7)
-		(margins 0.9525 0.9525 0.9525 0.9525)
-		(stroke
-			(width 0)
-			(type solid)
-			(color 255 0 0 1)
-		)
-		(fill
-			(type color)
-			(color 255 67 78 1)
-		)
-		(effects
-			(font
-				(size 1.27 1.27)
-				(color 0 0 0 1)
-			)
-			(justify left top)
-		)
-		(uuid "b5963943-570c-4c5c-b92b-1c751a8e07c0")
 	)
 	(text_box "Component Description\n"
 		(exclude_from_sim no)

--- a/kicad/power_supply.kicad_sch
+++ b/kicad/power_supply.kicad_sch
@@ -1030,6 +1030,113 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "seven_lib:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 	)
 	(text "\n\n"
 		(exclude_from_sim no)
@@ -1160,6 +1267,12 @@
 		(uuid "1c65d8c4-961b-41c7-9717-7acc6f332d2a")
 	)
 	(junction
+		(at 148.59 87.63)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "315242c0-0ad6-4c2c-9011-a330dfaca80f")
+	)
+	(junction
 		(at 48.26 90.17)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -1184,6 +1297,12 @@
 		(uuid "a5280603-824d-483b-a7bf-5f598368182c")
 	)
 	(junction
+		(at 53.34 102.87)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bd877209-48dc-4c06-8391-20a7a9a9b2ad")
+	)
+	(junction
 		(at 35.56 83.82)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -1194,6 +1313,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "c1802303-a4ef-498b-9628-927ff0b9d5c3")
+	)
+	(junction
+		(at 31.75 83.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c7626a1b-d547-406b-aef0-aa5f45d6b3e0")
 	)
 	(junction
 		(at 158.75 74.93)
@@ -1271,13 +1396,23 @@
 	)
 	(wire
 		(pts
-			(xy 53.34 87.63) (xy 53.34 105.41)
+			(xy 53.34 87.63) (xy 53.34 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "2a9eec25-91d2-48ee-aa4e-e1e440bd2277")
+	)
+	(wire
+		(pts
+			(xy 27.94 77.47) (xy 31.75 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2c25a95f-c0c1-441f-a79b-71631f01ef1a")
 	)
 	(polyline
 		(pts
@@ -1308,6 +1443,26 @@
 			(type default)
 		)
 		(uuid "3c5f9b78-f1ad-4799-925a-547dfcbf9fd1")
+	)
+	(wire
+		(pts
+			(xy 53.34 102.87) (xy 53.34 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4bf99478-6248-48bb-8017-c7b457602f4b")
+	)
+	(wire
+		(pts
+			(xy 31.75 83.82) (xy 35.56 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "53e5ec32-85e1-4f87-b2a2-e38e4f134aef")
 	)
 	(wire
 		(pts
@@ -1371,7 +1526,7 @@
 	)
 	(wire
 		(pts
-			(xy 30.48 83.82) (xy 35.56 83.82)
+			(xy 30.48 83.82) (xy 31.75 83.82)
 		)
 		(stroke
 			(width 0)
@@ -1421,7 +1576,7 @@
 	)
 	(wire
 		(pts
-			(xy 107.95 87.63) (xy 158.75 87.63)
+			(xy 107.95 87.63) (xy 148.59 87.63)
 		)
 		(stroke
 			(width 0)
@@ -1591,6 +1746,16 @@
 	)
 	(wire
 		(pts
+			(xy 31.75 77.47) (xy 31.75 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d7e50eca-1647-4c3a-83ec-be56c5097d42")
+	)
+	(wire
+		(pts
 			(xy 67.31 90.17) (xy 48.26 90.17)
 		)
 		(stroke
@@ -1598,6 +1763,16 @@
 			(type default)
 		)
 		(uuid "eb5f9a5b-3ad2-43c3-8008-c0565afca15b")
+	)
+	(wire
+		(pts
+			(xy 148.59 87.63) (xy 158.75 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ee16dbf3-ed13-4070-9340-123e279fe633")
 	)
 	(wire
 		(pts
@@ -2150,6 +2325,70 @@
 		)
 	)
 	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 27.94 77.47 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "55200fa6-1e5f-4dad-aa75-1d7ae49e2e98")
+		(property "Reference" "TP6"
+			(at 31.623 73.025 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "VDD_5V"
+			(at 31.623 75.565 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 33.02 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 33.02 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 27.94 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2a886f2b-0f46-42bd-8a1b-1295ac9cf786")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/212f259f-7773-4a20-96f5-c599a3d0b814"
+					(reference "TP6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "seven_lib:C")
 		(at 143.51 85.09 270)
 		(unit 1)
@@ -2553,6 +2792,70 @@
 		)
 	)
 	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 53.34 102.87 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "7b4c8f6c-8437-4167-bf67-198cbe61d9fa")
+		(property "Reference" "TP7"
+			(at 50.038 97.79 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "POWER_SUPPLY"
+			(at 52.324 100.33 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 53.34 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 53.34 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 53.34 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a1aeabf2-08d8-4782-a5f3-37dbbcdf1193")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/212f259f-7773-4a20-96f5-c599a3d0b814"
+					(reference "TP7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "seven_lib:GND")
 		(at 107.95 80.01 90)
 		(unit 1)
@@ -2614,6 +2917,70 @@
 			(project "seven"
 				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/212f259f-7773-4a20-96f5-c599a3d0b814"
 					(reference "#PWR022")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 148.59 87.63 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "878e7c14-226a-4292-8c34-864354e0cfb5")
+		(property "Reference" "TP8"
+			(at 144.653 89.535 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "FB"
+			(at 144.653 92.075 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 143.51 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 143.51 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 148.59 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "46c0478e-622c-4f9e-9949-e4db07e07c2f")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/212f259f-7773-4a20-96f5-c599a3d0b814"
+					(reference "TP8")
 					(unit 1)
 				)
 			)

--- a/kicad/reset_button.kicad_sch
+++ b/kicad/reset_button.kicad_sch
@@ -256,7 +256,7 @@
 				)
 			)
 			(property "Footprint" "seven-lib:SW_TL3336AF160Q"
-				(at 0 0 0)
+				(at 0 -24.638 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -266,7 +266,7 @@
 				)
 			)
 			(property "Datasheet" "https://www.mouser.se/datasheet/3/315/1/TL3336AF160Q.pdf"
-				(at 0 0 0)
+				(at -0.254 3.556 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -284,7 +284,7 @@
 				)
 			)
 			(property "MF" "E-Switch"
-				(at 0 0 0)
+				(at 0.762 -16.764 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -294,7 +294,7 @@
 				)
 			)
 			(property "MAXIMUM_PACKAGE_HEIGHT" "7.1mm"
-				(at 0 0 0)
+				(at -0.508 -27.178 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -304,7 +304,7 @@
 				)
 			)
 			(property "Package" "None"
-				(at 0 0 0)
+				(at 0.254 -33.782 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -324,7 +324,7 @@
 				)
 			)
 			(property "Check_prices" "https://www.snapeda.com/parts/TL3336AF160Q/E-Switch/view-part/?ref=eda"
-				(at 0 0 0)
+				(at -0.762 4.826 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -334,7 +334,7 @@
 				)
 			)
 			(property "STANDARD" "Manufacturer Recommendations"
-				(at 0 0 0)
+				(at 0 -4.826 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -344,7 +344,7 @@
 				)
 			)
 			(property "PARTREV" "3.30.2021"
-				(at 0 0 0)
+				(at 0.254 -22.352 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -354,7 +354,7 @@
 				)
 			)
 			(property "SnapEDA_Link" "https://www.snapeda.com/parts/TL3336AF160Q/E-Switch/view-part/?ref=snap"
-				(at 0 0 0)
+				(at 0.254 -9.652 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -364,7 +364,7 @@
 				)
 			)
 			(property "MP" "TL3336AF160Q"
-				(at 0 0 0)
+				(at 0.508 -12.954 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -374,7 +374,7 @@
 				)
 			)
 			(property "Purchase-URL" "https://www.snapeda.com/api/url_track_click_mouser/?unipart_id=5907806&manufacturer=E-Switch&part_name=TL3336AF160Q&search_term=None"
-				(at 0 0 0)
+				(at -0.762 7.366 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -384,7 +384,7 @@
 				)
 			)
 			(property "Description_1" "Tactile Switch, SPST-NO, OFF-(ON), Top Actuated, R/A, 0.05A, 12V, TL3336A Series | E-Switch TL3336AF160Q"
-				(at 0 0 0)
+				(at -1.016 -7.112 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -394,7 +394,7 @@
 				)
 			)
 			(property "MANUFACTURER" "E-Switch"
-				(at 0 0 0)
+				(at -0.508 -31.496 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -404,7 +404,7 @@
 				)
 			)
 			(property "Availability" "In Stock"
-				(at 0 0 0)
+				(at -0.254 -29.464 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -414,7 +414,7 @@
 				)
 			)
 			(property "SNAPEDA_PN" "TL3336AF160Q"
-				(at 0 0 0)
+				(at 0 -19.812 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -510,6 +510,113 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "seven_lib:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 	)
 	(text "\n\n"
 		(exclude_from_sim no)
@@ -586,6 +693,12 @@
 		(uuid "be0f3964-538d-4ffd-804b-72c3e6a0c368")
 	)
 	(junction
+		(at 66.04 92.71)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7296148f-1a8f-4452-8013-02ddeb99e8db")
+	)
+	(junction
 		(at 69.85 92.71)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -593,7 +706,27 @@
 	)
 	(wire
 		(pts
-			(xy 60.96 92.71) (xy 69.85 92.71)
+			(xy 66.04 99.06) (xy 66.04 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0012760c-bc65-471c-9cf0-9524054bb2d2")
+	)
+	(wire
+		(pts
+			(xy 66.04 92.71) (xy 69.85 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "06bd6351-9636-409e-9448-84f1e7599b58")
+	)
+	(wire
+		(pts
+			(xy 60.96 92.71) (xy 66.04 92.71)
 		)
 		(stroke
 			(width 0)
@@ -759,6 +892,70 @@
 			(project ""
 				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/fcef6494-c0b2-4cc5-a2e1-aeb845f0853f"
 					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 66.04 99.06 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "3c907f7d-899b-43cc-8fb1-de21677c75df")
+		(property "Reference" "TP11"
+			(at 62.103 100.965 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "RESET_BUTTON"
+			(at 62.103 103.505 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 60.96 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 60.96 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 66.04 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "955b0f74-1aa6-4572-b780-657ff4b1669d")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/fcef6494-c0b2-4cc5-a2e1-aeb845f0853f"
+					(reference "TP11")
 					(unit 1)
 				)
 			)

--- a/kicad/seven.kicad_sch
+++ b/kicad/seven.kicad_sch
@@ -175,7 +175,7 @@
 	)
 	(wire
 		(pts
-			(xy 100.33 69.85) (xy 100.33 77.47)
+			(xy 100.33 71.12) (xy 100.33 77.47)
 		)
 		(stroke
 			(width 0)
@@ -225,7 +225,7 @@
 	)
 	(wire
 		(pts
-			(xy 107.95 63.5) (xy 107.95 69.85)
+			(xy 107.95 64.77) (xy 107.95 71.12)
 		)
 		(stroke
 			(width 0)
@@ -282,6 +282,16 @@
 			(type default)
 		)
 		(uuid "683daf95-8f78-496f-b91a-ccba4725e694")
+	)
+	(wire
+		(pts
+			(xy 127 63.5) (xy 133.35 63.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6d87b1a3-cd79-4a87-b050-34d59bb91613")
 	)
 	(wire
 		(pts
@@ -385,7 +395,7 @@
 	)
 	(wire
 		(pts
-			(xy 107.95 69.85) (xy 100.33 69.85)
+			(xy 107.95 71.12) (xy 100.33 71.12)
 		)
 		(stroke
 			(width 0)
@@ -425,7 +435,7 @@
 	)
 	(wire
 		(pts
-			(xy 110.49 72.39) (xy 102.87 72.39)
+			(xy 110.49 73.66) (xy 102.87 73.66)
 		)
 		(stroke
 			(width 0)
@@ -435,7 +445,7 @@
 	)
 	(wire
 		(pts
-			(xy 110.49 63.5) (xy 110.49 72.39)
+			(xy 110.49 64.77) (xy 110.49 73.66)
 		)
 		(stroke
 			(width 0)
@@ -515,7 +525,7 @@
 	)
 	(wire
 		(pts
-			(xy 102.87 72.39) (xy 102.87 77.47)
+			(xy 102.87 73.66) (xy 102.87 77.47)
 		)
 		(stroke
 			(width 0)
@@ -602,6 +612,28 @@
 			(type default)
 		)
 		(uuid "f76c9c18-3cab-4170-9634-836f445fff85")
+	)
+	(global_label "VDD_JTAG"
+		(shape output)
+		(at 133.35 63.5 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "19011c9f-2241-4d1e-9b00-97909d9d0bc0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 145.2252 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
 	)
 	(global_label "VDD_1V8"
 		(shape output)
@@ -1405,7 +1437,7 @@
 	)
 	(sheet
 		(at 106.68 54.102)
-		(size 20.32 9.398)
+		(size 20.32 10.668)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
@@ -1438,7 +1470,7 @@
 			)
 		)
 		(pin "SDA" bidirectional
-			(at 110.49 63.5 270)
+			(at 110.49 64.77 270)
 			(uuid "dd196f63-0fe3-4254-9934-2de8fe6d3ec9")
 			(effects
 				(font
@@ -1448,7 +1480,7 @@
 			)
 		)
 		(pin "SCL" input
-			(at 107.95 63.5 270)
+			(at 107.95 64.77 270)
 			(uuid "3853615a-7ea1-4f5e-87a2-6316b166055c")
 			(effects
 				(font
@@ -1480,6 +1512,16 @@
 		(pin "VDD_1V8" output
 			(at 127 55.88 0)
 			(uuid "133e2bc7-a3a8-4a94-a3ce-f93302d6327b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "VDD_JTAG" output
+			(at 127 63.5 0)
+			(uuid "a7bc5452-4c0a-416a-9743-5be9db05b5a2")
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/kicad/sym-lib/seven_lib.kicad_sym
+++ b/kicad/sym-lib/seven_lib.kicad_sym
@@ -3912,7 +3912,7 @@
 			)
 		)
 		(property "Footprint" "seven-lib:SW_TL3336AF160Q"
-			(at 0 0 0)
+			(at 0 -24.638 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3922,7 +3922,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.mouser.se/datasheet/3/315/1/TL3336AF160Q.pdf"
-			(at 0 0 0)
+			(at -0.254 3.556 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3940,7 +3940,7 @@
 			)
 		)
 		(property "MF" "E-Switch"
-			(at 0 0 0)
+			(at 0.762 -16.764 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3950,7 +3950,7 @@
 			)
 		)
 		(property "MAXIMUM_PACKAGE_HEIGHT" "7.1mm"
-			(at 0 0 0)
+			(at -0.508 -27.178 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3960,7 +3960,7 @@
 			)
 		)
 		(property "Package" "None"
-			(at 0 0 0)
+			(at 0.254 -33.782 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3980,7 +3980,7 @@
 			)
 		)
 		(property "Check_prices" "https://www.snapeda.com/parts/TL3336AF160Q/E-Switch/view-part/?ref=eda"
-			(at 0 0 0)
+			(at -0.762 4.826 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3990,7 +3990,7 @@
 			)
 		)
 		(property "STANDARD" "Manufacturer Recommendations"
-			(at 0 0 0)
+			(at 0 -4.826 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4000,7 +4000,7 @@
 			)
 		)
 		(property "PARTREV" "3.30.2021"
-			(at 0 0 0)
+			(at 0.254 -22.352 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4010,7 +4010,7 @@
 			)
 		)
 		(property "SnapEDA_Link" "https://www.snapeda.com/parts/TL3336AF160Q/E-Switch/view-part/?ref=snap"
-			(at 0 0 0)
+			(at 0.254 -9.652 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4020,7 +4020,7 @@
 			)
 		)
 		(property "MP" "TL3336AF160Q"
-			(at 0 0 0)
+			(at 0.508 -12.954 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4030,7 +4030,7 @@
 			)
 		)
 		(property "Purchase-URL" "https://www.snapeda.com/api/url_track_click_mouser/?unipart_id=5907806&manufacturer=E-Switch&part_name=TL3336AF160Q&search_term=None"
-			(at 0 0 0)
+			(at -0.762 7.366 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4040,7 +4040,7 @@
 			)
 		)
 		(property "Description_1" "Tactile Switch, SPST-NO, OFF-(ON), Top Actuated, R/A, 0.05A, 12V, TL3336A Series | E-Switch TL3336AF160Q"
-			(at 0 0 0)
+			(at -1.016 -7.112 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4050,7 +4050,7 @@
 			)
 		)
 		(property "MANUFACTURER" "E-Switch"
-			(at 0 0 0)
+			(at -0.508 -31.496 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4060,7 +4060,7 @@
 			)
 		)
 		(property "Availability" "In Stock"
-			(at 0 0 0)
+			(at -0.254 -29.464 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4070,7 +4070,7 @@
 			)
 		)
 		(property "SNAPEDA_PN" "TL3336AF160Q"
-			(at 0 0 0)
+			(at 0 -19.812 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4631,6 +4631,113 @@
 					)
 				)
 				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "TestPoint"
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0.762)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "TP"
+			(at 0 6.858 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TestPoint"
+			(at 0 5.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 5.08 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 5.08 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "test point tp"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "Pin* Test*"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "TestPoint_0_1"
+			(circle
+				(center 0 3.302)
+				(radius 0.762)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "TestPoint_1_1"
+			(pin passive line
+				(at 0 0 90)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
 					(effects
 						(font
 							(size 1.27 1.27)

--- a/kicad/system_LED.kicad_sch
+++ b/kicad/system_LED.kicad_sch
@@ -725,6 +725,113 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "seven_lib:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 	)
 	(text "\n\n"
 		(exclude_from_sim no)
@@ -854,6 +961,12 @@
 		(color 0 0 0 0)
 		(uuid "4f838a69-c93b-470f-81a7-7dab1403f333")
 	)
+	(junction
+		(at 83.82 85.09)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6df8ab97-d6d1-4f1d-8865-7e50b568f89c")
+	)
 	(no_connect
 		(at 101.6 85.09)
 		(uuid "bd0a7704-6c71-4b66-85e0-98ced4d9fd8c")
@@ -910,7 +1023,17 @@
 	)
 	(wire
 		(pts
-			(xy 81.28 85.09) (xy 86.36 85.09)
+			(xy 83.82 90.17) (xy 83.82 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "be97cc0f-272a-4110-916a-9b670360794e")
+	)
+	(wire
+		(pts
+			(xy 81.28 85.09) (xy 83.82 85.09)
 		)
 		(stroke
 			(width 0)
@@ -947,6 +1070,16 @@
 			(type default)
 		)
 		(uuid "eb6e1118-df5f-4362-99a2-e6d332e56505")
+	)
+	(wire
+		(pts
+			(xy 83.82 85.09) (xy 86.36 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f0c722ed-b0ea-4ab9-aef5-24bfc05f49a5")
 	)
 	(global_label "VDD_5V"
 		(shape input)
@@ -1278,6 +1411,70 @@
 			(project "system_LED"
 				(path "/a4797295-7784-4336-a44a-01a52d7306a1"
 					(reference "R?")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "seven_lib:TestPoint")
+		(at 83.82 90.17 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "77a82d95-0726-44e5-887e-e513b4649113")
+		(property "Reference" "TP5"
+			(at 79.883 92.075 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SYSTEM_LED"
+			(at 79.883 94.615 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "seven-lib:TestPoint_Pad_2.0x2.0mm"
+			(at 78.74 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 83.82 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "70d362b8-fb40-40e3-86b0-0b62a2b0cfa0")
+		)
+		(instances
+			(project "seven"
+				(path "/8e3cc843-5797-49f3-8b3a-1c11450ccd1e/57402695-b5b6-411c-ba67-6244479e2395"
+					(reference "TP5")
 					(unit 1)
 				)
 			)


### PR DESCRIPTION
After a meeting in the ID8 office, we found some last things to change prior to PCB design. These are:

- Add test pads for easier testing/debugging  
- Set default GPIO voltage to 3.3V with jumper option for 1.8V  
- Review MCU GND pin connections/layout  
- Add diode to nPM1300 (for protection/power path)  
- Add I2C pull-up resistors for PMIC  
- Change PMIC I2C pins to match nRF DK reference design  